### PR TITLE
feat: added support for additional metadata fields using Borsh DTO de-serialization

### DIFF
--- a/packages/cryptoplease/lib/features/nft/bl/offchain_metadata_repository.dart
+++ b/packages/cryptoplease/lib/features/nft/bl/offchain_metadata_repository.dart
@@ -5,7 +5,7 @@ class OffchainMetadataRepository {
 
   Future<OffChainMetadata> getMetadata(Metadata metadata) async =>
       _requests.putIfAbsent(
-        metadata.mint,
+        metadata.mint.toBase58(),
         () => metadata.getExternalJson(),
       );
 }

--- a/packages/cryptoplease/lib/features/nft/presentation/nft_details_screen.dart
+++ b/packages/cryptoplease/lib/features/nft/presentation/nft_details_screen.dart
@@ -95,7 +95,7 @@ class _Content extends StatelessWidget {
                 text: context.l10n.send,
                 onPressed: () {
                   final token = NonFungibleToken(
-                    address: metadata.mint,
+                    address: metadata.mint.toBase58(),
                     metadata: metadata,
                   );
 

--- a/packages/solana/lib/src/encoder/compiled_message.freezed.dart
+++ b/packages/solana/lib/src/encoder/compiled_message.freezed.dart
@@ -123,7 +123,7 @@ abstract class _CompiledMessage extends CompiledMessage {
   const _CompiledMessage._() : super._();
 
   @override
-  ByteArray get data => throw _privateConstructorUsedError;
+  ByteArray get data;
   @override
   @JsonKey(ignore: true)
   _$$_CompiledMessageCopyWith<_$_CompiledMessage> get copyWith =>

--- a/packages/solana/lib/src/metaplex/collection_details.dart
+++ b/packages/solana/lib/src/metaplex/collection_details.dart
@@ -1,0 +1,14 @@
+import 'package:borsh_annotation/borsh_annotation.dart';
+part 'collection_details.g.dart';
+
+@BorshSerializable()
+class CollectionDetails with _$CollectionDetails {
+  factory CollectionDetails({
+    @BU64() required BigInt size,
+  }) = _CollectionDetails;
+
+  const CollectionDetails._();
+
+  factory CollectionDetails.fromBorsh(Uint8List data) =>
+      _$CollectionDetailsFromBorsh(data);
+}

--- a/packages/solana/lib/src/metaplex/collection_details.g.dart
+++ b/packages/solana/lib/src/metaplex/collection_details.g.dart
@@ -1,0 +1,49 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'collection_details.dart';
+
+// **************************************************************************
+// BorshSerializableGenerator
+// **************************************************************************
+
+mixin _$CollectionDetails {
+  BigInt get size => throw UnimplementedError();
+
+  Uint8List toBorsh() {
+    final writer = BinaryWriter();
+
+    const BU64().write(writer, size);
+
+    return writer.toArray();
+  }
+}
+
+class _CollectionDetails extends CollectionDetails {
+  _CollectionDetails({
+    required this.size,
+  }) : super._();
+
+  final BigInt size;
+}
+
+class BCollectionDetails implements BType<CollectionDetails> {
+  const BCollectionDetails();
+
+  @override
+  void write(BinaryWriter writer, CollectionDetails value) {
+    writer.writeStruct(value.toBorsh());
+  }
+
+  @override
+  CollectionDetails read(BinaryReader reader) {
+    return CollectionDetails(
+      size: const BU64().read(reader),
+    );
+  }
+}
+
+CollectionDetails _$CollectionDetailsFromBorsh(Uint8List data) {
+  final reader = BinaryReader(data.buffer.asByteData());
+
+  return const BCollectionDetails().read(reader);
+}

--- a/packages/solana/lib/src/metaplex/creator.dart
+++ b/packages/solana/lib/src/metaplex/creator.dart
@@ -1,0 +1,18 @@
+import 'package:borsh_annotation/borsh_annotation.dart';
+import 'package:solana/solana.dart';
+import 'package:solana/src/borsh_ext.dart';
+
+part 'creator.g.dart';
+
+@BorshSerializable()
+class Creator with _$Creator {
+  factory Creator({
+    @BPublicKey() required Ed25519HDPublicKey address,
+    @BBool() required bool verified,
+    @BU8() required int share,
+  }) = _Creator;
+
+  const Creator._();
+
+  factory Creator.fromBorsh(Uint8List data) => _$CreatorFromBorsh(data);
+}

--- a/packages/solana/lib/src/metaplex/creator.g.dart
+++ b/packages/solana/lib/src/metaplex/creator.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'creator.dart';
+
+// **************************************************************************
+// BorshSerializableGenerator
+// **************************************************************************
+
+mixin _$Creator {
+  Ed25519HDPublicKey get address => throw UnimplementedError();
+  bool get verified => throw UnimplementedError();
+  int get share => throw UnimplementedError();
+
+  Uint8List toBorsh() {
+    final writer = BinaryWriter();
+
+    const BPublicKey().write(writer, address);
+    const BBool().write(writer, verified);
+    const BU8().write(writer, share);
+
+    return writer.toArray();
+  }
+}
+
+class _Creator extends Creator {
+  _Creator({
+    required this.address,
+    required this.verified,
+    required this.share,
+  }) : super._();
+
+  final Ed25519HDPublicKey address;
+  final bool verified;
+  final int share;
+}
+
+class BCreator implements BType<Creator> {
+  const BCreator();
+
+  @override
+  void write(BinaryWriter writer, Creator value) {
+    writer.writeStruct(value.toBorsh());
+  }
+
+  @override
+  Creator read(BinaryReader reader) {
+    return Creator(
+      address: const BPublicKey().read(reader),
+      verified: const BBool().read(reader),
+      share: const BU8().read(reader),
+    );
+  }
+}
+
+Creator _$CreatorFromBorsh(Uint8List data) {
+  final reader = BinaryReader(data.buffer.asByteData());
+
+  return const BCreator().read(reader);
+}

--- a/packages/solana/lib/src/metaplex/metadata.g.dart
+++ b/packages/solana/lib/src/metaplex/metadata.g.dart
@@ -1,0 +1,119 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'metadata.dart';
+
+// **************************************************************************
+// BorshSerializableGenerator
+// **************************************************************************
+
+mixin _$Metadata {
+  int get key => throw UnimplementedError();
+  Ed25519HDPublicKey get updateAuthority => throw UnimplementedError();
+  Ed25519HDPublicKey get mint => throw UnimplementedError();
+  String get name => throw UnimplementedError();
+  String get symbol => throw UnimplementedError();
+  String get uri => throw UnimplementedError();
+  int get sellerFeeBasisPoints => throw UnimplementedError();
+  List<Creator>? get creators => throw UnimplementedError();
+  bool get primarySaleHappened => throw UnimplementedError();
+  bool get isMutable => throw UnimplementedError();
+  int? get editionNonce => throw UnimplementedError();
+  int? get tokenStandard => throw UnimplementedError();
+  OnChainCollection? get collection => throw UnimplementedError();
+  Uses? get uses => throw UnimplementedError();
+  CollectionDetails? get collectionDetails => throw UnimplementedError();
+
+  Uint8List toBorsh() {
+    final writer = BinaryWriter();
+
+    const BU8().write(writer, key);
+    const BPublicKey().write(writer, updateAuthority);
+    const BPublicKey().write(writer, mint);
+    const BString().write(writer, name);
+    const BString().write(writer, symbol);
+    const BString().write(writer, uri);
+    const BU16().write(writer, sellerFeeBasisPoints);
+    const BOption(BArray(BCreator())).write(writer, creators);
+    const BBool().write(writer, primarySaleHappened);
+    const BBool().write(writer, isMutable);
+    const BOption(BU8()).write(writer, editionNonce);
+    const BOption(BU8()).write(writer, tokenStandard);
+    const BOption(BOnChainCollection()).write(writer, collection);
+    const BOption(BUses()).write(writer, uses);
+    const BOption(BCollectionDetails()).write(writer, collectionDetails);
+
+    return writer.toArray();
+  }
+}
+
+class _Metadata extends Metadata {
+  _Metadata({
+    required this.key,
+    required this.updateAuthority,
+    required this.mint,
+    required this.name,
+    required this.symbol,
+    required this.uri,
+    required this.sellerFeeBasisPoints,
+    required this.creators,
+    required this.primarySaleHappened,
+    required this.isMutable,
+    required this.editionNonce,
+    required this.tokenStandard,
+    required this.collection,
+    required this.uses,
+    required this.collectionDetails,
+  }) : super._();
+
+  final int key;
+  final Ed25519HDPublicKey updateAuthority;
+  final Ed25519HDPublicKey mint;
+  final String name;
+  final String symbol;
+  final String uri;
+  final int sellerFeeBasisPoints;
+  final List<Creator>? creators;
+  final bool primarySaleHappened;
+  final bool isMutable;
+  final int? editionNonce;
+  final int? tokenStandard;
+  final OnChainCollection? collection;
+  final Uses? uses;
+  final CollectionDetails? collectionDetails;
+}
+
+class BMetadata implements BType<Metadata> {
+  const BMetadata();
+
+  @override
+  void write(BinaryWriter writer, Metadata value) {
+    writer.writeStruct(value.toBorsh());
+  }
+
+  @override
+  Metadata read(BinaryReader reader) {
+    return Metadata(
+      key: const BU8().read(reader),
+      updateAuthority: const BPublicKey().read(reader),
+      mint: const BPublicKey().read(reader),
+      name: const BString().read(reader),
+      symbol: const BString().read(reader),
+      uri: const BString().read(reader),
+      sellerFeeBasisPoints: const BU16().read(reader),
+      creators: const BOption(BArray(BCreator())).read(reader),
+      primarySaleHappened: const BBool().read(reader),
+      isMutable: const BBool().read(reader),
+      editionNonce: const BOption(BU8()).read(reader),
+      tokenStandard: const BOption(BU8()).read(reader),
+      collection: const BOption(BOnChainCollection()).read(reader),
+      uses: const BOption(BUses()).read(reader),
+      collectionDetails: const BOption(BCollectionDetails()).read(reader),
+    );
+  }
+}
+
+Metadata _$MetadataFromBorsh(Uint8List data) {
+  final reader = BinaryReader(data.buffer.asByteData());
+
+  return const BMetadata().read(reader);
+}

--- a/packages/solana/lib/src/metaplex/on_chain_collection.dart
+++ b/packages/solana/lib/src/metaplex/on_chain_collection.dart
@@ -1,0 +1,18 @@
+import 'package:borsh_annotation/borsh_annotation.dart';
+import 'package:solana/solana.dart';
+import 'package:solana/src/borsh_ext.dart';
+
+part 'on_chain_collection.g.dart';
+
+@BorshSerializable()
+class OnChainCollection with _$OnChainCollection {
+  factory OnChainCollection({
+    @BBool() required bool verified,
+    @BPublicKey() required Ed25519HDPublicKey key,
+  }) = _OnChainCollection;
+
+  const OnChainCollection._();
+
+  factory OnChainCollection.fromBorsh(Uint8List data) =>
+      _$OnChainCollectionFromBorsh(data);
+}

--- a/packages/solana/lib/src/metaplex/on_chain_collection.g.dart
+++ b/packages/solana/lib/src/metaplex/on_chain_collection.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'on_chain_collection.dart';
+
+// **************************************************************************
+// BorshSerializableGenerator
+// **************************************************************************
+
+mixin _$OnChainCollection {
+  bool get verified => throw UnimplementedError();
+  Ed25519HDPublicKey get key => throw UnimplementedError();
+
+  Uint8List toBorsh() {
+    final writer = BinaryWriter();
+
+    const BBool().write(writer, verified);
+    const BPublicKey().write(writer, key);
+
+    return writer.toArray();
+  }
+}
+
+class _OnChainCollection extends OnChainCollection {
+  _OnChainCollection({
+    required this.verified,
+    required this.key,
+  }) : super._();
+
+  final bool verified;
+  final Ed25519HDPublicKey key;
+}
+
+class BOnChainCollection implements BType<OnChainCollection> {
+  const BOnChainCollection();
+
+  @override
+  void write(BinaryWriter writer, OnChainCollection value) {
+    writer.writeStruct(value.toBorsh());
+  }
+
+  @override
+  OnChainCollection read(BinaryReader reader) {
+    return OnChainCollection(
+      verified: const BBool().read(reader),
+      key: const BPublicKey().read(reader),
+    );
+  }
+}
+
+OnChainCollection _$OnChainCollectionFromBorsh(Uint8List data) {
+  final reader = BinaryReader(data.buffer.asByteData());
+
+  return const BOnChainCollection().read(reader);
+}

--- a/packages/solana/lib/src/metaplex/properties.freezed.dart
+++ b/packages/solana/lib/src/metaplex/properties.freezed.dart
@@ -245,7 +245,9 @@ class _$Unknown implements Unknown {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$UnknownToJson(this);
+    return _$$UnknownToJson(
+      this,
+    );
   }
 }
 
@@ -414,7 +416,9 @@ class _$Video implements Video {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$VideoToJson(this);
+    return _$$VideoToJson(
+      this,
+    );
   }
 }
 
@@ -423,7 +427,7 @@ abstract class Video implements Properties {
 
   factory Video.fromJson(Map<String, dynamic> json) = _$Video.fromJson;
 
-  List<File> get files => throw _privateConstructorUsedError;
+  List<File> get files;
   @JsonKey(ignore: true)
   _$$VideoCopyWith<_$Video> get copyWith => throw _privateConstructorUsedError;
 }
@@ -587,7 +591,9 @@ class _$Image implements Image {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ImageToJson(this);
+    return _$$ImageToJson(
+      this,
+    );
   }
 }
 
@@ -596,7 +602,7 @@ abstract class Image implements Properties {
 
   factory Image.fromJson(Map<String, dynamic> json) = _$Image.fromJson;
 
-  List<File> get files => throw _privateConstructorUsedError;
+  List<File> get files;
   @JsonKey(ignore: true)
   _$$ImageCopyWith<_$Image> get copyWith => throw _privateConstructorUsedError;
 }
@@ -761,7 +767,9 @@ class _$Model3D implements Model3D {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$Model3DToJson(this);
+    return _$$Model3DToJson(
+      this,
+    );
   }
 }
 
@@ -770,7 +778,7 @@ abstract class Model3D implements Properties {
 
   factory Model3D.fromJson(Map<String, dynamic> json) = _$Model3D.fromJson;
 
-  List<File> get files => throw _privateConstructorUsedError;
+  List<File> get files;
   @JsonKey(ignore: true)
   _$$Model3DCopyWith<_$Model3D> get copyWith =>
       throw _privateConstructorUsedError;
@@ -935,7 +943,9 @@ class _$Audio implements Audio {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AudioToJson(this);
+    return _$$AudioToJson(
+      this,
+    );
   }
 }
 
@@ -944,7 +954,7 @@ abstract class Audio implements Properties {
 
   factory Audio.fromJson(Map<String, dynamic> json) = _$Audio.fromJson;
 
-  List<File> get files => throw _privateConstructorUsedError;
+  List<File> get files;
   @JsonKey(ignore: true)
   _$$AudioCopyWith<_$Audio> get copyWith => throw _privateConstructorUsedError;
 }
@@ -1108,7 +1118,9 @@ class _$Html implements Html {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$HtmlToJson(this);
+    return _$$HtmlToJson(
+      this,
+    );
   }
 }
 
@@ -1117,7 +1129,7 @@ abstract class Html implements Properties {
 
   factory Html.fromJson(Map<String, dynamic> json) = _$Html.fromJson;
 
-  List<File> get files => throw _privateConstructorUsedError;
+  List<File> get files;
   @JsonKey(ignore: true)
   _$$HtmlCopyWith<_$Html> get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/metaplex/rpc_client_ext.dart
+++ b/packages/solana/lib/src/metaplex/rpc_client_ext.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:solana/solana.dart';
 import 'package:solana/src/encoder/byte_array.dart';
 import 'package:solana/src/metaplex/metaplex.dart';
@@ -27,7 +29,7 @@ extension GetMetaplexMetadata on RpcClient {
     final data = account.data;
 
     if (data is BinaryAccountData) {
-      return Metadata.fromBinary(data.data);
+      return Metadata.fromBorsh(Uint8List.fromList(data.data));
     } else {
       return null;
     }

--- a/packages/solana/lib/src/metaplex/uses.dart
+++ b/packages/solana/lib/src/metaplex/uses.dart
@@ -1,0 +1,15 @@
+import 'package:borsh_annotation/borsh_annotation.dart';
+part 'uses.g.dart';
+
+@BorshSerializable()
+class Uses with _$Uses {
+  factory Uses({
+    @BU8() required int useMethod,
+    @BU64() required BigInt remaining,
+    @BU64() required BigInt total,
+  }) = _Uses;
+
+  const Uses._();
+
+  factory Uses.fromBorsh(Uint8List data) => _$UsesFromBorsh(data);
+}

--- a/packages/solana/lib/src/metaplex/uses.g.dart
+++ b/packages/solana/lib/src/metaplex/uses.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'uses.dart';
+
+// **************************************************************************
+// BorshSerializableGenerator
+// **************************************************************************
+
+mixin _$Uses {
+  int get useMethod => throw UnimplementedError();
+  BigInt get remaining => throw UnimplementedError();
+  BigInt get total => throw UnimplementedError();
+
+  Uint8List toBorsh() {
+    final writer = BinaryWriter();
+
+    const BU8().write(writer, useMethod);
+    const BU64().write(writer, remaining);
+    const BU64().write(writer, total);
+
+    return writer.toArray();
+  }
+}
+
+class _Uses extends Uses {
+  _Uses({
+    required this.useMethod,
+    required this.remaining,
+    required this.total,
+  }) : super._();
+
+  final int useMethod;
+  final BigInt remaining;
+  final BigInt total;
+}
+
+class BUses implements BType<Uses> {
+  const BUses();
+
+  @override
+  void write(BinaryWriter writer, Uses value) {
+    writer.writeStruct(value.toBorsh());
+  }
+
+  @override
+  Uses read(BinaryReader reader) {
+    return Uses(
+      useMethod: const BU8().read(reader),
+      remaining: const BU64().read(reader),
+      total: const BU64().read(reader),
+    );
+  }
+}
+
+Uses _$UsesFromBorsh(Uint8List data) {
+  final reader = BinaryReader(data.buffer.asByteData());
+
+  return const BUses().read(reader);
+}

--- a/packages/solana/lib/src/programs/token_program/mint.freezed.dart
+++ b/packages/solana/lib/src/programs/token_program/mint.freezed.dart
@@ -250,15 +250,15 @@ abstract class _Mint implements Mint {
   @override
 
   /// Address of the mint
-  Ed25519HDPublicKey get address => throw _privateConstructorUsedError;
+  Ed25519HDPublicKey get address;
   @override
 
   /// Total supply of tokens.
-  BigInt get supply => throw _privateConstructorUsedError;
+  BigInt get supply;
   @override
 
   /// Number of base 10 digits to the right of the decimal place.
-  int get decimals => throw _privateConstructorUsedError;
+  int get decimals;
   @override
 
   /// Optional authority used to mint new tokens.
@@ -266,15 +266,15 @@ abstract class _Mint implements Mint {
   /// The mint authority may only be provided during mint creation. If no mint
   /// authority is present then the mint has a fixed supply and no further
   /// tokens may be minted.
-  Ed25519HDPublicKey? get mintAuthority => throw _privateConstructorUsedError;
+  Ed25519HDPublicKey? get mintAuthority;
   @override
 
   /// Is this mint initialized
-  bool get isInitialized => throw _privateConstructorUsedError;
+  bool get isInitialized;
   @override
 
   /// Optional authority to freeze token accounts.
-  Ed25519HDPublicKey? get freezeAuthority => throw _privateConstructorUsedError;
+  Ed25519HDPublicKey? get freezeAuthority;
   @override
   @JsonKey(ignore: true)
   _$$_MintCopyWith<_$_Mint> get copyWith => throw _privateConstructorUsedError;

--- a/packages/solana/lib/src/rpc/client.g.dart
+++ b/packages/solana/lib/src/rpc/client.g.dart
@@ -9,7 +9,7 @@ part of 'client.dart';
 Map<String, dynamic> _$GetAccountInfoConfigToJson(
     GetAccountInfoConfig instance) {
   final val = <String, dynamic>{
-    'commitment': _$CommitmentEnumMap[instance.commitment],
+    'commitment': _$CommitmentEnumMap[instance.commitment]!,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -235,7 +235,7 @@ Map<String, dynamic> _$GetMinimumBalanceForRentExemptionConfigToJson(
 Map<String, dynamic> _$GetMultipleAccountsConfigToJson(
     GetMultipleAccountsConfig instance) {
   final val = <String, dynamic>{
-    'commitment': _$CommitmentEnumMap[instance.commitment],
+    'commitment': _$CommitmentEnumMap[instance.commitment]!,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -260,7 +260,7 @@ Map<String, dynamic> _$GetProgramAccountsConfigToJson(
   }
 
   writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  val['encoding'] = _$EncodingEnumMap[instance.encoding];
+  val['encoding'] = _$EncodingEnumMap[instance.encoding]!;
   writeNotNull('dataSlice', instance.dataSlice?.toJson());
   writeNotNull('filters', instance.filters?.map((e) => e.toJson()).toList());
   return val;
@@ -354,7 +354,7 @@ Map<String, dynamic> _$GetStakeActivationConfigToJson(
 
 Map<String, dynamic> _$GetSupplyConfigToJson(GetSupplyConfig instance) {
   final val = <String, dynamic>{
-    'commitment': _$CommitmentEnumMap[instance.commitment],
+    'commitment': _$CommitmentEnumMap[instance.commitment]!,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -385,7 +385,7 @@ Map<String, dynamic> _$GetTokenAccountBalanceConfigToJson(
 Map<String, dynamic> _$GetTokenAccountsByDelegateConfigToJson(
     GetTokenAccountsByDelegateConfig instance) {
   final val = <String, dynamic>{
-    'commitment': _$CommitmentEnumMap[instance.commitment],
+    'commitment': _$CommitmentEnumMap[instance.commitment]!,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -402,7 +402,7 @@ Map<String, dynamic> _$GetTokenAccountsByDelegateConfigToJson(
 Map<String, dynamic> _$GetTokenAccountsByOwnerConfigToJson(
     GetTokenAccountsByOwnerConfig instance) {
   final val = <String, dynamic>{
-    'commitment': _$CommitmentEnumMap[instance.commitment],
+    'commitment': _$CommitmentEnumMap[instance.commitment]!,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -507,7 +507,7 @@ Map<String, dynamic> _$RequestAirdropConfigToJson(
 Map<String, dynamic> _$SendTransactionConfigToJson(
     SendTransactionConfig instance) {
   final val = <String, dynamic>{
-    'encoding': _$EncodingEnumMap[instance.encoding],
+    'encoding': _$EncodingEnumMap[instance.encoding]!,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -534,7 +534,7 @@ Map<String, dynamic> _$SimulateTransactionConfigToJson(
   }
 
   writeNotNull('sigVerify', instance.sigVerify);
-  val['encoding'] = _$EncodingEnumMap[instance.encoding];
+  val['encoding'] = _$EncodingEnumMap[instance.encoding]!;
   writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
   writeNotNull('replaceRecentBlockhash', instance.replaceRecentBlockhash);
   writeNotNull('accounts', instance.accounts?.toJson());

--- a/packages/solana/lib/src/rpc/dto/account_data/parsed_account_data.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/account_data/parsed_account_data.freezed.dart
@@ -248,7 +248,9 @@ class _$ParsedSplTokenProgramAccountData
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedSplTokenProgramAccountDataToJson(this);
+    return _$$ParsedSplTokenProgramAccountDataToJson(
+      this,
+    );
   }
 }
 
@@ -260,7 +262,7 @@ abstract class ParsedSplTokenProgramAccountData implements ParsedAccountData {
   factory ParsedSplTokenProgramAccountData.fromJson(Map<String, dynamic> json) =
       _$ParsedSplTokenProgramAccountData.fromJson;
 
-  SplTokenProgramAccountData get parsed => throw _privateConstructorUsedError;
+  SplTokenProgramAccountData get parsed;
   @JsonKey(ignore: true)
   _$$ParsedSplTokenProgramAccountDataCopyWith<
           _$ParsedSplTokenProgramAccountData>
@@ -420,7 +422,9 @@ class _$ParsedStakeProgramAccountData implements ParsedStakeProgramAccountData {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedStakeProgramAccountDataToJson(this);
+    return _$$ParsedStakeProgramAccountDataToJson(
+      this,
+    );
   }
 }
 
@@ -431,7 +435,7 @@ abstract class ParsedStakeProgramAccountData implements ParsedAccountData {
   factory ParsedStakeProgramAccountData.fromJson(Map<String, dynamic> json) =
       _$ParsedStakeProgramAccountData.fromJson;
 
-  StakeProgramAccountData get parsed => throw _privateConstructorUsedError;
+  StakeProgramAccountData get parsed;
   @JsonKey(ignore: true)
   _$$ParsedStakeProgramAccountDataCopyWith<_$ParsedStakeProgramAccountData>
       get copyWith => throw _privateConstructorUsedError;
@@ -587,7 +591,9 @@ class _$UnsupportedProgramAccountData implements UnsupportedProgramAccountData {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$UnsupportedProgramAccountDataToJson(this);
+    return _$$UnsupportedProgramAccountDataToJson(
+      this,
+    );
   }
 }
 
@@ -598,7 +604,7 @@ abstract class UnsupportedProgramAccountData implements ParsedAccountData {
   factory UnsupportedProgramAccountData.fromJson(Map<String, dynamic> json) =
       _$UnsupportedProgramAccountData.fromJson;
 
-  Map<String, dynamic> get parsed => throw _privateConstructorUsedError;
+  Map<String, dynamic> get parsed;
   @JsonKey(ignore: true)
   _$$UnsupportedProgramAccountDataCopyWith<_$UnsupportedProgramAccountData>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/solana/lib/src/rpc/dto/account_data/spl_token_program/token_program_account_data.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/account_data/spl_token_program/token_program_account_data.freezed.dart
@@ -293,7 +293,9 @@ class _$TokenAccountData implements TokenAccountData {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$TokenAccountDataToJson(this);
+    return _$$TokenAccountDataToJson(
+      this,
+    );
   }
 }
 
@@ -306,10 +308,10 @@ abstract class TokenAccountData implements SplTokenProgramAccountData {
   factory TokenAccountData.fromJson(Map<String, dynamic> json) =
       _$TokenAccountData.fromJson;
 
-  SplTokenAccountDataInfo get info => throw _privateConstructorUsedError;
+  SplTokenAccountDataInfo get info;
   @override
-  String get type => throw _privateConstructorUsedError;
-  String? get accountType => throw _privateConstructorUsedError;
+  String get type;
+  String? get accountType;
   @override
   @JsonKey(ignore: true)
   _$$TokenAccountDataCopyWith<_$TokenAccountData> get copyWith =>
@@ -487,7 +489,9 @@ class _$MintAccountData implements MintAccountData {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$MintAccountDataToJson(this);
+    return _$$MintAccountDataToJson(
+      this,
+    );
   }
 }
 
@@ -500,10 +504,10 @@ abstract class MintAccountData implements SplTokenProgramAccountData {
   factory MintAccountData.fromJson(Map<String, dynamic> json) =
       _$MintAccountData.fromJson;
 
-  MintAccountDataInfo get info => throw _privateConstructorUsedError;
+  MintAccountDataInfo get info;
   @override
-  String get type => throw _privateConstructorUsedError;
-  String? get accountType => throw _privateConstructorUsedError;
+  String get type;
+  String? get accountType;
   @override
   @JsonKey(ignore: true)
   _$$MintAccountDataCopyWith<_$MintAccountData> get copyWith =>
@@ -661,7 +665,9 @@ class _$UnknownAccountData implements UnknownAccountData {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$UnknownAccountDataToJson(this);
+    return _$$UnknownAccountDataToJson(
+      this,
+    );
   }
 }
 
@@ -673,7 +679,7 @@ abstract class UnknownAccountData implements SplTokenProgramAccountData {
       _$UnknownAccountData.fromJson;
 
   @override
-  String get type => throw _privateConstructorUsedError;
+  String get type;
   @override
   @JsonKey(ignore: true)
   _$$UnknownAccountDataCopyWith<_$UnknownAccountData> get copyWith =>

--- a/packages/solana/lib/src/rpc/dto/account_data/stake_program/stake_program_account_data.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/account_data/stake_program/stake_program_account_data.freezed.dart
@@ -243,7 +243,9 @@ class _$StakeProgramDelegatedAccountData
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$StakeProgramDelegatedAccountDataToJson(this);
+    return _$$StakeProgramDelegatedAccountDataToJson(
+      this,
+    );
   }
 }
 
@@ -256,7 +258,7 @@ abstract class StakeProgramDelegatedAccountData
   factory StakeProgramDelegatedAccountData.fromJson(Map<String, dynamic> json) =
       _$StakeProgramDelegatedAccountData.fromJson;
 
-  StakeDelegatedAccountInfo get info => throw _privateConstructorUsedError;
+  StakeDelegatedAccountInfo get info;
   @JsonKey(ignore: true)
   _$$StakeProgramDelegatedAccountDataCopyWith<
           _$StakeProgramDelegatedAccountData>
@@ -412,7 +414,9 @@ class _$StakeProgramInitializedAccountData
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$StakeProgramInitializedAccountDataToJson(this);
+    return _$$StakeProgramInitializedAccountDataToJson(
+      this,
+    );
   }
 }
 
@@ -426,7 +430,7 @@ abstract class StakeProgramInitializedAccountData
           Map<String, dynamic> json) =
       _$StakeProgramInitializedAccountData.fromJson;
 
-  StakeInitializedAccountInfo get info => throw _privateConstructorUsedError;
+  StakeInitializedAccountInfo get info;
   @JsonKey(ignore: true)
   _$$StakeProgramInitializedAccountDataCopyWith<
           _$StakeProgramInitializedAccountData>
@@ -586,7 +590,9 @@ class _$StakeProgramUnknownAccountData
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$StakeProgramUnknownAccountDataToJson(this);
+    return _$$StakeProgramUnknownAccountDataToJson(
+      this,
+    );
   }
 }
 
@@ -598,7 +604,7 @@ abstract class StakeProgramUnknownAccountData
   factory StakeProgramUnknownAccountData.fromJson(Map<String, dynamic> json) =
       _$StakeProgramUnknownAccountData.fromJson;
 
-  Map<String, dynamic> get info => throw _privateConstructorUsedError;
+  Map<String, dynamic> get info;
   @JsonKey(ignore: true)
   _$$StakeProgramUnknownAccountDataCopyWith<_$StakeProgramUnknownAccountData>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/solana/lib/src/rpc/dto/parsed_message/parsed_instruction.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/parsed_message/parsed_instruction.freezed.dart
@@ -270,7 +270,9 @@ class _$ParsedInstructionSystem implements ParsedInstructionSystem {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedInstructionSystemToJson(this);
+    return _$$ParsedInstructionSystemToJson(
+      this,
+    );
   }
 }
 
@@ -283,8 +285,8 @@ abstract class ParsedInstructionSystem implements ParsedInstruction {
   factory ParsedInstructionSystem.fromJson(Map<String, dynamic> json) =
       _$ParsedInstructionSystem.fromJson;
 
-  String get programId => throw _privateConstructorUsedError;
-  ParsedSystemInstruction get parsed => throw _privateConstructorUsedError;
+  String get programId;
+  ParsedSystemInstruction get parsed;
   @JsonKey(ignore: true)
   _$$ParsedInstructionSystemCopyWith<_$ParsedInstructionSystem> get copyWith =>
       throw _privateConstructorUsedError;
@@ -449,7 +451,9 @@ class _$ParsedInstructionSplToken implements ParsedInstructionSplToken {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedInstructionSplTokenToJson(this);
+    return _$$ParsedInstructionSplTokenToJson(
+      this,
+    );
   }
 }
 
@@ -461,7 +465,7 @@ abstract class ParsedInstructionSplToken implements ParsedInstruction {
   factory ParsedInstructionSplToken.fromJson(Map<String, dynamic> json) =
       _$ParsedInstructionSplToken.fromJson;
 
-  ParsedSplTokenInstruction get parsed => throw _privateConstructorUsedError;
+  ParsedSplTokenInstruction get parsed;
   @JsonKey(ignore: true)
   _$$ParsedInstructionSplTokenCopyWith<_$ParsedInstructionSplToken>
       get copyWith => throw _privateConstructorUsedError;
@@ -619,7 +623,9 @@ class _$ParsedInstructionMemo implements ParsedInstructionMemo {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedInstructionMemoToJson(this);
+    return _$$ParsedInstructionMemoToJson(
+      this,
+    );
   }
 }
 
@@ -634,7 +640,7 @@ abstract class ParsedInstructionMemo implements ParsedInstruction {
 // This ignore is needed until https://github.com/dart-lang/linter/issues/2778 is fixed
 // ignore: invalid_annotation_target
   @JsonKey(name: 'parsed')
-  String? get memo => throw _privateConstructorUsedError;
+  String? get memo;
   @JsonKey(ignore: true)
   _$$ParsedInstructionMemoCopyWith<_$ParsedInstructionMemo> get copyWith =>
       throw _privateConstructorUsedError;
@@ -787,7 +793,9 @@ class _$ParsedInstructionUnsupported implements ParsedInstructionUnsupported {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedInstructionUnsupportedToJson(this);
+    return _$$ParsedInstructionUnsupportedToJson(
+      this,
+    );
   }
 }
 
@@ -798,7 +806,7 @@ abstract class ParsedInstructionUnsupported implements ParsedInstruction {
   factory ParsedInstructionUnsupported.fromJson(Map<String, dynamic> json) =
       _$ParsedInstructionUnsupported.fromJson;
 
-  String? get program => throw _privateConstructorUsedError;
+  String? get program;
   @JsonKey(ignore: true)
   _$$ParsedInstructionUnsupportedCopyWith<_$ParsedInstructionUnsupported>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/solana/lib/src/rpc/dto/parsed_message/parsed_spl_token_instruction.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/parsed_message/parsed_spl_token_instruction.freezed.dart
@@ -278,7 +278,9 @@ class _$ParsedSplTokenTransferInstruction
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedSplTokenTransferInstructionToJson(this);
+    return _$$ParsedSplTokenTransferInstructionToJson(
+      this,
+    );
   }
 }
 
@@ -291,9 +293,9 @@ abstract class ParsedSplTokenTransferInstruction
   factory ParsedSplTokenTransferInstruction.fromJson(
       Map<String, dynamic> json) = _$ParsedSplTokenTransferInstruction.fromJson;
 
-  SplTokenTransferInfo get info => throw _privateConstructorUsedError;
+  SplTokenTransferInfo get info;
   @override
-  String get type => throw _privateConstructorUsedError;
+  String get type;
   @override
   @JsonKey(ignore: true)
   _$$ParsedSplTokenTransferInstructionCopyWith<
@@ -464,7 +466,9 @@ class _$ParsedSplTokenTransferCheckedInstruction
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedSplTokenTransferCheckedInstructionToJson(this);
+    return _$$ParsedSplTokenTransferCheckedInstructionToJson(
+      this,
+    );
   }
 }
 
@@ -478,9 +482,9 @@ abstract class ParsedSplTokenTransferCheckedInstruction
           Map<String, dynamic> json) =
       _$ParsedSplTokenTransferCheckedInstruction.fromJson;
 
-  SplTokenTransferCheckedInfo get info => throw _privateConstructorUsedError;
+  SplTokenTransferCheckedInfo get info;
   @override
-  String get type => throw _privateConstructorUsedError;
+  String get type;
   @override
   @JsonKey(ignore: true)
   _$$ParsedSplTokenTransferCheckedInstructionCopyWith<
@@ -650,7 +654,9 @@ class _$ParsedSplTokenGenericInstruction
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedSplTokenGenericInstructionToJson(this);
+    return _$$ParsedSplTokenGenericInstructionToJson(
+      this,
+    );
   }
 }
 
@@ -663,9 +669,9 @@ abstract class ParsedSplTokenGenericInstruction
   factory ParsedSplTokenGenericInstruction.fromJson(Map<String, dynamic> json) =
       _$ParsedSplTokenGenericInstruction.fromJson;
 
-  dynamic get info => throw _privateConstructorUsedError;
+  dynamic get info;
   @override
-  String get type => throw _privateConstructorUsedError;
+  String get type;
   @override
   @JsonKey(ignore: true)
   _$$ParsedSplTokenGenericInstructionCopyWith<

--- a/packages/solana/lib/src/rpc/dto/parsed_message/parsed_system_instruction.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/parsed_message/parsed_system_instruction.freezed.dart
@@ -294,7 +294,9 @@ class _$ParsedSystemTransferInstruction
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedSystemTransferInstructionToJson(this);
+    return _$$ParsedSystemTransferInstructionToJson(
+      this,
+    );
   }
 }
 
@@ -307,10 +309,9 @@ abstract class ParsedSystemTransferInstruction
   factory ParsedSystemTransferInstruction.fromJson(Map<String, dynamic> json) =
       _$ParsedSystemTransferInstruction.fromJson;
 
-  ParsedSystemTransferInformation get info =>
-      throw _privateConstructorUsedError;
+  ParsedSystemTransferInformation get info;
   @override
-  String get type => throw _privateConstructorUsedError;
+  String get type;
   @override
   @JsonKey(ignore: true)
   _$$ParsedSystemTransferInstructionCopyWith<_$ParsedSystemTransferInstruction>
@@ -493,7 +494,9 @@ class _$ParsedSystemTransferCheckedInstruction
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedSystemTransferCheckedInstructionToJson(this);
+    return _$$ParsedSystemTransferCheckedInstructionToJson(
+      this,
+    );
   }
 }
 
@@ -507,10 +510,9 @@ abstract class ParsedSystemTransferCheckedInstruction
           Map<String, dynamic> json) =
       _$ParsedSystemTransferCheckedInstruction.fromJson;
 
-  ParsedSystemTransferInformation get info =>
-      throw _privateConstructorUsedError;
+  ParsedSystemTransferInformation get info;
   @override
-  String get type => throw _privateConstructorUsedError;
+  String get type;
   @override
   @JsonKey(ignore: true)
   _$$ParsedSystemTransferCheckedInstructionCopyWith<
@@ -673,7 +675,9 @@ class _$ParsedSystemUnsupportedInstruction
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedSystemUnsupportedInstructionToJson(this);
+    return _$$ParsedSystemUnsupportedInstructionToJson(
+      this,
+    );
   }
 }
 
@@ -687,7 +691,7 @@ abstract class ParsedSystemUnsupportedInstruction
       _$ParsedSystemUnsupportedInstruction.fromJson;
 
   @override
-  String get type => throw _privateConstructorUsedError;
+  String get type;
   @override
   @JsonKey(ignore: true)
   _$$ParsedSystemUnsupportedInstructionCopyWith<
@@ -853,7 +857,9 @@ class _$_ParsedSystemTransferInformation
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ParsedSystemTransferInformationToJson(this);
+    return _$$_ParsedSystemTransferInformationToJson(
+      this,
+    );
   }
 }
 
@@ -868,11 +874,11 @@ abstract class _ParsedSystemTransferInformation
       _$_ParsedSystemTransferInformation.fromJson;
 
   @override
-  int get lamports => throw _privateConstructorUsedError;
+  int get lamports;
   @override
-  String get source => throw _privateConstructorUsedError;
+  String get source;
   @override
-  String get destination => throw _privateConstructorUsedError;
+  String get destination;
   @override
   @JsonKey(ignore: true)
   _$$_ParsedSystemTransferInformationCopyWith<

--- a/packages/solana/lib/src/solana_pay/solana_pay_request.freezed.dart
+++ b/packages/solana/lib/src/solana_pay/solana_pay_request.freezed.dart
@@ -244,20 +244,19 @@ abstract class _SolanaPayRequest extends SolanaPayRequest {
   const _SolanaPayRequest._() : super._();
 
   @override
-  Ed25519HDPublicKey get recipient => throw _privateConstructorUsedError;
+  Ed25519HDPublicKey get recipient;
   @override
-  Decimal? get amount => throw _privateConstructorUsedError;
+  Decimal? get amount;
   @override
-  Ed25519HDPublicKey? get splToken => throw _privateConstructorUsedError;
+  Ed25519HDPublicKey? get splToken;
   @override
-  Iterable<Ed25519HDPublicKey>? get reference =>
-      throw _privateConstructorUsedError;
+  Iterable<Ed25519HDPublicKey>? get reference;
   @override
-  String? get label => throw _privateConstructorUsedError;
+  String? get label;
   @override
-  String? get message => throw _privateConstructorUsedError;
+  String? get message;
   @override
-  String? get memo => throw _privateConstructorUsedError;
+  String? get memo;
   @override
   @JsonKey(ignore: true)
   _$$_SolanaPayRequestCopyWith<_$_SolanaPayRequest> get copyWith =>

--- a/packages/solana/lib/src/subscription_client/logs_filter.freezed.dart
+++ b/packages/solana/lib/src/subscription_client/logs_filter.freezed.dart
@@ -442,7 +442,7 @@ abstract class _LogsFilterMentions implements LogsFilter {
   const factory _LogsFilterMentions(final List<String> pubKeys) =
       _$_LogsFilterMentions;
 
-  List<String> get pubKeys => throw _privateConstructorUsedError;
+  List<String> get pubKeys;
   @JsonKey(ignore: true)
   _$$_LogsFilterMentionsCopyWith<_$_LogsFilterMentions> get copyWith =>
       throw _privateConstructorUsedError;

--- a/packages/solana/lib/src/subscription_client/notification_message.freezed.dart
+++ b/packages/solana/lib/src/subscription_client/notification_message.freezed.dart
@@ -265,7 +265,9 @@ class _$_UnsupportedNotification extends _UnsupportedNotification {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_UnsupportedNotificationToJson(this);
+    return _$$_UnsupportedNotificationToJson(
+      this,
+    );
   }
 }
 
@@ -443,7 +445,9 @@ class _$AccountNotification extends AccountNotification {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AccountNotificationToJson(this);
+    return _$$AccountNotificationToJson(
+      this,
+    );
   }
 }
 
@@ -456,7 +460,7 @@ abstract class AccountNotification extends NotificationMessage {
   factory AccountNotification.fromJson(Map<String, dynamic> json) =
       _$AccountNotification.fromJson;
 
-  NotificationParams<Account> get params => throw _privateConstructorUsedError;
+  NotificationParams<Account> get params;
   @JsonKey(ignore: true)
   _$$AccountNotificationCopyWith<_$AccountNotification> get copyWith =>
       throw _privateConstructorUsedError;
@@ -627,7 +631,9 @@ class _$LogsNotification extends LogsNotification {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$LogsNotificationToJson(this);
+    return _$$LogsNotificationToJson(
+      this,
+    );
   }
 }
 
@@ -639,7 +645,7 @@ abstract class LogsNotification extends NotificationMessage {
   factory LogsNotification.fromJson(Map<String, dynamic> json) =
       _$LogsNotification.fromJson;
 
-  NotificationParams<Logs> get params => throw _privateConstructorUsedError;
+  NotificationParams<Logs> get params;
   @JsonKey(ignore: true)
   _$$LogsNotificationCopyWith<_$LogsNotification> get copyWith =>
       throw _privateConstructorUsedError;
@@ -811,7 +817,9 @@ class _$ProgramNotification extends ProgramNotification {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ProgramNotificationToJson(this);
+    return _$$ProgramNotificationToJson(
+      this,
+    );
   }
 }
 
@@ -824,7 +832,7 @@ abstract class ProgramNotification extends NotificationMessage {
   factory ProgramNotification.fromJson(Map<String, dynamic> json) =
       _$ProgramNotification.fromJson;
 
-  NotificationParams<dynamic> get params => throw _privateConstructorUsedError;
+  NotificationParams<dynamic> get params;
   @JsonKey(ignore: true)
   _$$ProgramNotificationCopyWith<_$ProgramNotification> get copyWith =>
       throw _privateConstructorUsedError;
@@ -996,7 +1004,9 @@ class _$SignatureNotification extends SignatureNotification {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SignatureNotificationToJson(this);
+    return _$$SignatureNotificationToJson(
+      this,
+    );
   }
 }
 
@@ -1009,8 +1019,7 @@ abstract class SignatureNotification extends NotificationMessage {
   factory SignatureNotification.fromJson(Map<String, dynamic> json) =
       _$SignatureNotification.fromJson;
 
-  NotificationParams<OptionalError> get params =>
-      throw _privateConstructorUsedError;
+  NotificationParams<OptionalError> get params;
   @JsonKey(ignore: true)
   _$$SignatureNotificationCopyWith<_$SignatureNotification> get copyWith =>
       throw _privateConstructorUsedError;
@@ -1181,7 +1190,9 @@ class _$SlotNotification extends SlotNotification {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SlotNotificationToJson(this);
+    return _$$SlotNotificationToJson(
+      this,
+    );
   }
 }
 
@@ -1193,7 +1204,7 @@ abstract class SlotNotification extends NotificationMessage {
   factory SlotNotification.fromJson(Map<String, dynamic> json) =
       _$SlotNotification.fromJson;
 
-  NotificationParams<Slot> get params => throw _privateConstructorUsedError;
+  NotificationParams<Slot> get params;
   @JsonKey(ignore: true)
   _$$SlotNotificationCopyWith<_$SlotNotification> get copyWith =>
       throw _privateConstructorUsedError;

--- a/packages/solana/test/metaplex/metadata_test.dart
+++ b/packages/solana/test/metaplex/metadata_test.dart
@@ -1,3 +1,4 @@
+import 'package:borsh_annotation/borsh_annotation.dart';
 import 'package:solana/metaplex.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
@@ -39,7 +40,7 @@ void main() {
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       0, 0,
     ];
-    final metadata = Metadata.fromBinary(binary);
+    final metadata = Metadata.fromBorsh(Uint8List.fromList(binary));
     expect(
       metadata,
       isA<Metadata>()


### PR DESCRIPTION
## Changes

Converted `Metadata` to Borsh DTO and added support for de-serialization of additional fields like: `key`, `sellerFeeBasisPoints`, `creators`, `primarySaleHappened`, `isMutable`, `editionNonce`, `tokenStandard`, `collection`, `uses`, and `collectionDetails`.

## Related issues

Fixes #272 #175

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
