### PR TITLE
fix: token price overflow on investment screen

### DIFF
--- a/packages/espressocash_app/lib/features/popular_tokens/widgets/popular_token_list.dart
+++ b/packages/espressocash_app/lib/features/popular_tokens/widgets/popular_token_list.dart
@@ -89,14 +89,21 @@ class _TokenItem extends StatelessWidget {
             _TokenSymbolWidget(token.symbol),
           ],
         ),
-        trailing: Text(
-          tokenRate.format(locale),
-          style: const TextStyle(
-            fontWeight: FontWeight.w700,
-            fontSize: 15,
-            color: Colors.black,
+        trailing: ConstrainedBox(
+          constraints: const BoxConstraints.tightFor(width: 63),
+          child: FittedBox(
+            fit: BoxFit.none,
+            alignment: Alignment.centerRight,
+            child: Text(
+              tokenRate.format(locale),
+              style: const TextStyle(
+                fontWeight: FontWeight.w700,
+                fontSize: 15,
+                color: Colors.black,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
-          overflow: TextOverflow.ellipsis,
         ),
       ),
     );

--- a/packages/espressocash_app/pubspec.lock
+++ b/packages/espressocash_app/pubspec.lock
@@ -1927,5 +1927,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"
   flutter: ">=3.3.0"

--- a/packages/espressocash_app/pubspec.lock
+++ b/packages/espressocash_app/pubspec.lock
@@ -1927,5 +1927,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=2.19.0 <3.0.0"
   flutter: ">=3.3.0"


### PR DESCRIPTION
## Changes

- Fix token price overflow for popular crypto items on investment screen

## Screenshots

<details><summary>Bug evidence</summary>

![Captura de Tela 2023-02-08 às 15 36 57](https://user-images.githubusercontent.com/19499575/217630073-c7451cc5-5699-4d57-aea4-aa7371abba2b.png)

</details>

<details><summary>Screenshot</summary>

Added some screenshots from other phones (iPhone 14 Pro Max, iPhone SE 3rd gen) to ensure it did not break on those.

![Captura de Tela 2023-02-08 às 16 11 25](https://user-images.githubusercontent.com/19499575/217630460-8208438a-b818-4f3d-949f-b705a9ba8157.png)
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-08 at 16 11 33](https://user-images.githubusercontent.com/19499575/217630467-55e3bd2d-9475-452d-bdc3-2e50a2e42a7c.png)
![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-08 at 16 11 47](https://user-images.githubusercontent.com/19499575/217630468-31ff68a0-2c18-4973-b0ab-ee159fe18eb2.png)

</details>

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
