### PR TITLE
perf: add RepaintBoundary to OnboardingNotice

### DIFF
--- a/packages/espressocash_app/lib/features/onboarding/widgets/onboarding_notice.dart
+++ b/packages/espressocash_app/lib/features/onboarding/widgets/onboarding_notice.dart
@@ -17,11 +17,13 @@ class OnboardingNotice extends StatelessWidget {
             : Container(
                 height: 125,
                 margin: const EdgeInsets.only(bottom: 24),
-                child: GestureDetector(
-                  onTap: () =>
-                      context.router.navigate(const OnboardingFlowRoute()),
-                  child: Assets.rive.onboardingNotice.rive(
-                    fit: BoxFit.fitWidth,
+                child: RepaintBoundary(
+                  child: GestureDetector(
+                    onTap: () =>
+                        context.router.navigate(const OnboardingFlowRoute()),
+                    child: Assets.rive.onboardingNotice.rive(
+                      fit: BoxFit.fitWidth,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Changes

Added `RepaintBoundary` to `OnboardingNotice` to prevent repainting the whole screen due to the animation.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
