### PR TITLE
feat: use asLegacyTransaction for jupiter swap

### DIFF
--- a/packages/espressocash_backend/lib/src/swap/jupiter_repository.dart
+++ b/packages/espressocash_backend/lib/src/swap/jupiter_repository.dart
@@ -58,7 +58,11 @@ class JupiterRepository {
 
     final tx = await _swapClient
         .getSwapTransactions(
-          JupiterSwapRequestDto(userPublicKey: account, route: bestRoute),
+          JupiterSwapRequestDto(
+            userPublicKey: account,
+            route: bestRoute,
+            asLegacyTransaction: asLegacyTransaction,
+          ),
         )
         .then((jupiterTxs) => jupiterTxs.swapTransaction);
 


### PR DESCRIPTION
## Changes

Add support for legacy tx on swap (related to https://github.com/espresso-cash/espresso-cash-public/pull/792)

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
