### PR TITLE
feat: pop status screen when going to share screen for the first time

### DIFF
--- a/packages/espressocash_app/lib/features/outgoing_split_key_payments/src/widgets/oskp_screen.dart
+++ b/packages/espressocash_app/lib/features/outgoing_split_key_payments/src/widgets/oskp_screen.dart
@@ -48,7 +48,7 @@ class _OSKPScreenState extends State<OSKPScreen> {
       final status = payment.status as OSKPStatusLinksReady;
 
       context.router
-          .push(ShareLinksRoute(amount: payment.amount, status: status));
+          .popAndPush(ShareLinksRoute(amount: payment.amount, status: status));
       _shareLinksSubscription?.cancel();
     });
   }


### PR DESCRIPTION
## Changes

When clicking back button on share link screen for first time, go directly to home screen tabs

## Video

https://user-images.githubusercontent.com/28533130/219415760-083b5dfe-5dde-4163-8ba2-ca57aa79adad.mp4


## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
