### PR TITLE
fix: confirmation dialog label

### DIFF
--- a/packages/espressocash_app/lib/app/screens/authenticated/profile/components/danger_section.dart
+++ b/packages/espressocash_app/lib/app/screens/authenticated/profile/components/danger_section.dart
@@ -10,6 +10,7 @@ class DangerSection extends StatelessWidget {
         onConfirm: () {
           context.read<AccountsBloc>().add(const AccountsEvent.loggedOut());
         },
+        confirmLabel: context.l10n.yesDeleteMyWallet,
       );
 
   @override

--- a/packages/espressocash_app/lib/ui/dialogs.dart
+++ b/packages/espressocash_app/lib/ui/dialogs.dart
@@ -28,6 +28,7 @@ Future<void> showConfirmationDialog(
   required String title,
   required String message,
   required void Function() onConfirm,
+  String? confirmLabel,
 }) =>
     showModalBottomSheet(
       context: context,
@@ -65,7 +66,7 @@ Future<void> showConfirmationDialog(
               ),
               const SizedBox(height: 32),
               CpButton(
-                text: context.l10n.yesDeleteMyWallet,
+                text: confirmLabel ?? context.l10n.yes,
                 width: double.infinity,
                 onPressed: () {
                   Navigator.pop(context);


### PR DESCRIPTION
## Changes

- Sets confirmation label as parameter on confirmation dialog

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
