### PR TITLE
feat: improve dialogs ui

### DIFF
--- a/packages/espressocash_app/lib/ui/dialogs.dart
+++ b/packages/espressocash_app/lib/ui/dialogs.dart
@@ -32,6 +32,8 @@ Future<void> showConfirmationDialog(
 }) =>
     showModalBottomSheet(
       context: context,
+      elevation: 0,
+      barrierColor: _barrierColor,
       backgroundColor: CpColors.primaryColor,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.only(
@@ -92,8 +94,10 @@ Future<void> showWarningDialog(
 }) =>
     showDialog(
       context: context,
+      barrierColor: _barrierColor,
       builder: (context) => CpTheme.dark(
         child: Dialog(
+          elevation: 0,
           backgroundColor: CpColors.primaryColor,
           insetPadding: const EdgeInsets.symmetric(horizontal: 24),
           shape: const RoundedRectangleBorder(
@@ -138,3 +142,5 @@ Future<void> showWarningDialog(
         ),
       ),
     );
+
+final _barrierColor = Colors.black.withOpacity(0.75);


### PR DESCRIPTION
## Changes

- Increases dim in the background;
- Changes font size for dialogs and bottom sheets.

<details><summary>Before</summary>

![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-21 at 15 50 20](https://user-images.githubusercontent.com/19499575/220436247-281c7fa0-5e8f-4b64-a9e6-e4d9e4cc3918.png)
![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-21 at 15 50 39](https://user-images.githubusercontent.com/19499575/220436262-351cad19-3825-46f8-8ed1-768adf525894.png)
![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-21 at 15 50 48](https://user-images.githubusercontent.com/19499575/220436270-d5a66e81-3695-4d84-9236-d0297a1dfcd8.png)

</details>


<details><summary>After</summary>

![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-21 at 16 18 35](https://user-images.githubusercontent.com/19499575/220438535-112ef1e4-bafd-4f15-b0e2-406e1310f7d8.png)
![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-21 at 16 18 53](https://user-images.githubusercontent.com/19499575/220438545-39f3f570-f2a5-4dd5-b7d1-f67f437cc633.png)
![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-21 at 16 19 03](https://user-images.githubusercontent.com/19499575/220438547-40b72b8a-65c2-476e-852c-ff533032c43a.png)

</details>

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
