### PR TITLE
fix: expand qr scanner button tap size

### DIFF
--- a/packages/espressocash_app/lib/app/screens/authenticated/wallet_flow/wallet_main_screen.dart
+++ b/packages/espressocash_app/lib/app/screens/authenticated/wallet_flow/wallet_main_screen.dart
@@ -174,6 +174,7 @@ class _QrScannerAppBar extends StatelessWidget implements PreferredSizeWidget {
                     onPressed: onQrScanner,
                     icon: Assets.icons.qrScanner.svg(height: 26),
                     padding: EdgeInsets.zero,
+                    alignment: Alignment.centerLeft,
                   ),
                 ),
                 Align(

--- a/packages/espressocash_app/lib/app/screens/authenticated/wallet_flow/wallet_main_screen.dart
+++ b/packages/espressocash_app/lib/app/screens/authenticated/wallet_flow/wallet_main_screen.dart
@@ -170,13 +170,10 @@ class _QrScannerAppBar extends StatelessWidget implements PreferredSizeWidget {
               children: [
                 Align(
                   alignment: Alignment.centerLeft,
-                  child: SizedBox.square(
-                    dimension: _qrButtonSize,
-                    child: IconButton(
-                      onPressed: onQrScanner,
-                      icon: Assets.icons.qrScanner.svg(height: _qrButtonSize),
-                      padding: EdgeInsets.zero,
-                    ),
+                  child: IconButton(
+                    onPressed: onQrScanner,
+                    icon: Assets.icons.qrScanner.svg(height: 26),
+                    padding: EdgeInsets.zero,
                   ),
                 ),
                 Align(
@@ -210,5 +207,3 @@ extension on WalletOperation {
 }
 
 enum WalletOperation { pay, request }
-
-const _qrButtonSize = 36.0;

--- a/packages/espressocash_app/lib/app/screens/authenticated/wallet_flow/wallet_main_screen.dart
+++ b/packages/espressocash_app/lib/app/screens/authenticated/wallet_flow/wallet_main_screen.dart
@@ -171,10 +171,10 @@ class _QrScannerAppBar extends StatelessWidget implements PreferredSizeWidget {
                 Align(
                   alignment: Alignment.centerLeft,
                   child: SizedBox.square(
-                    dimension: 26,
+                    dimension: _qrButtonSize,
                     child: IconButton(
                       onPressed: onQrScanner,
-                      icon: Assets.icons.qrScanner.svg(height: 26),
+                      icon: Assets.icons.qrScanner.svg(height: _qrButtonSize),
                       padding: EdgeInsets.zero,
                     ),
                   ),
@@ -210,3 +210,5 @@ extension on WalletOperation {
 }
 
 enum WalletOperation { pay, request }
+
+const _qrButtonSize = 36.0;


### PR DESCRIPTION
## Changes

Expand qr button tap size in wallet screen

## Related issues

Fixes #833

## Screenshots

Note: Green indicator not visible, for debugging purposes only to show tap area

<details><summary>Before</summary>

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-23 at 15 34 01](https://user-images.githubusercontent.com/28533130/220844716-3595339d-3290-489e-8ef5-c20a3780ab2a.png)

</details>

<details><summary>After</summary>

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-23 at 15 35 01](https://user-images.githubusercontent.com/28533130/220844741-90cfbc22-135b-4d5c-a46e-8dade54afbb4.png)

</details>

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
