### PR TITLE
fix: seed vault notification stream, account filter for parsed seeds

### DIFF
--- a/packages/solana_seed_vault/lib/src/extensions.dart
+++ b/packages/solana_seed_vault/lib/src/extensions.dart
@@ -11,15 +11,22 @@ import 'package:solana_seed_vault/src/seed_vault.dart';
 import 'package:solana_seed_vault/src/wallet_contract_v1.dart';
 
 extension SeedVaultHelperExt on SeedVault {
-  Future<List<Seed>> getParsedAuthorizedSeeds() async {
+  Future<List<Seed>> getParsedAuthorizedSeeds({
+    AccountFilter accountFilter = const AccountFilter(),
+  }) async {
     final result = await getAuthorizedSeeds();
 
-    return result.map((it) => it.cursorToSeed(this)).let(Future.wait);
+    return result
+        .map((it) => it.cursorToSeed(this, accountFilter))
+        .let(Future.wait);
   }
 
-  Future<Seed> getParsedAuthorizedSeed(AuthToken authToken) =>
+  Future<Seed> getParsedAuthorizedSeed(
+    AuthToken authToken, {
+    AccountFilter accountFilter = const AccountFilter(),
+  }) =>
       getAuthorizedSeed(authToken: authToken)
-          .letAsync((it) => it.cursorToSeed(this));
+          .letAsync((it) => it.cursorToSeed(this, accountFilter));
 
   Future<List<Account>> getParsedAccounts(
     AuthToken authToken, {
@@ -46,13 +53,13 @@ extension SeedVaultHelperExt on SeedVault {
 }
 
 extension CursorToModelExt on CursorData {
-  Future<Seed> cursorToSeed(SeedVault seedVault) async {
+  Future<Seed> cursorToSeed(SeedVault seedVault, AccountFilter filter) async {
     final authToken = this[WalletContractV1.authorizedSeedsAuthToken] as int;
     final name = this[WalletContractV1.authorizedSeedsSeedName] as String;
     final purpose = this[WalletContractV1.authorizedSeedsAuthPurpose] as int;
     final accounts = await seedVault.getParsedAccounts(
       authToken,
-      filter: const AccountFilter.byIsUserWallet(true),
+      filter: filter,
     );
 
     return Seed(

--- a/packages/solana_seed_vault/lib/src/seed_vault.dart
+++ b/packages/solana_seed_vault/lib/src/seed_vault.dart
@@ -33,7 +33,7 @@ class SeedVault implements SeedVaultFlutterApi {
   @visibleForTesting
   static set instance(SeedVault vault) => _instance = vault;
 
-  final _eventStream = StreamController<SeedVaultNotification>();
+  final _eventStream = StreamController<SeedVaultNotification>.broadcast();
 
   @override
   void onChangeNotified(List<String?> uris, int flags) {


### PR DESCRIPTION
## Changes

- Sets notification stream to be broadcast instead of single-subscriber;
- Adds `AccountFilter` as parameter when retrieving parsed seeds. 

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
