### PR TITLE
fix: Parse getFeeForMessage response

### DIFF
--- a/packages/solana/lib/src/rpc/client.rpc.dart
+++ b/packages/solana/lib/src/rpc/client.rpc.dart
@@ -243,7 +243,7 @@ class _RpcClient implements RpcClient {
         if (config.isNotEmpty) config,
       ],
     );
-    final dynamic value = getResult(response);
+    final dynamic value = unwrapAndGetResult(response);
 
     return (value == null) ? null : value as int;
   }


### PR DESCRIPTION
## Changes

Currently, `getFeeForMessage` throws an exception when the result comes back. The response isn't being parsed correctly. This patch fixes this issue and returns the correct fee `value` integer

## Related issues

n/a

## Checklist

- [X] PR is ready for review (if not, it should be a draft).
- [X] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [X] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
