### PR TITLE
feat: remove duplicate edit profile menu option

### DIFF
--- a/packages/espressocash_app/lib/app/screens/authenticated/profile/components/learning_section.dart
+++ b/packages/espressocash_app/lib/app/screens/authenticated/profile/components/learning_section.dart
@@ -7,20 +7,14 @@ import '../../../../../routes.gr.dart';
 import 'menu_button.dart';
 import 'profile_section.dart';
 
-class AboutSection extends StatelessWidget {
-  const AboutSection({super.key});
+class LearningSection extends StatelessWidget {
+  const LearningSection({super.key});
 
   @override
   Widget build(BuildContext context) => ProfileSection(
         title: context.l10n.learningSectionTitle,
         padding: const EdgeInsets.symmetric(vertical: 16),
         actions: [
-          MenuButton(
-            title: context.l10n.editProfile,
-            description: context.l10n.editProfileDescription,
-            icon: Assets.icons.visibility,
-            onTap: () => context.router.push(const EditProfileRoute()),
-          ),
           MenuButton(
             title: context.l10n.learnAboutCrypto,
             description: context.l10n.learnAboutCryptoDescription,

--- a/packages/espressocash_app/lib/app/screens/authenticated/profile/profile_screen.dart
+++ b/packages/espressocash_app/lib/app/screens/authenticated/profile/profile_screen.dart
@@ -14,7 +14,7 @@ import '../../../../features/qr_scanner/models/qr_address_data.dart';
 import '../../../../gen/assets.gen.dart';
 import '../../../../ui/icon_button.dart';
 import '../../../../ui/user_avatar.dart';
-import 'components/about_section.dart';
+import 'components/learning_section.dart';
 import 'components/profile_section.dart';
 import 'components/security_section.dart';
 
@@ -100,7 +100,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     children: const [
                       EditProfileSection(),
                       SecuritySection(),
-                      AboutSection(),
+                      LearningSection(),
                       DangerSection(),
                       ShareSection(),
                       VersionSection(),


### PR DESCRIPTION
## Changes

- Remove duplicate "Edit Profile" menu option;
- Rename `AboutSection` to `LearningSection` to keep consistency.

<details><summary>Screenshot</summary>

![Captura de Tela 2023-04-04 às 02 21 03](https://user-images.githubusercontent.com/19499575/229694187-90106d4c-53c1-4dd8-805c-750adc8f10ad.png)

</details>

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
