### PR TITLE
feat: don't show manual input button after first qr scanned

### DIFF
--- a/packages/espressocash_app/lib/features/incoming_split_key_payments/src/widgets/first_part_qr_screen.dart
+++ b/packages/espressocash_app/lib/features/incoming_split_key_payments/src/widgets/first_part_qr_screen.dart
@@ -22,8 +22,8 @@ class FirstPartQrScreen extends StatefulWidget {
 
 class _FirstPartQrScreenState extends State<FirstPartQrScreen> {
   Future<void> _onQrScanner() async {
-    final request =
-        await context.router.push<QrScannerRequest>(const QrScannerRoute());
+    final request = await context.router
+        .push<QrScannerRequest>(QrScannerRoute(showManualInput: false));
 
     if (request == null) return;
     if (!mounted) return;

--- a/packages/espressocash_app/lib/features/qr_scanner/src/widgets/qr_scanner_screen.dart
+++ b/packages/espressocash_app/lib/features/qr_scanner/src/widgets/qr_scanner_screen.dart
@@ -18,17 +18,24 @@ import 'components/input_address_bottom_sheet.dart';
 import 'components/qr_scanner_background.dart';
 
 class QrScannerScreen extends StatelessWidget {
-  const QrScannerScreen({Key? key}) : super(key: key);
+  const QrScannerScreen({
+    super.key,
+    this.showManualInput = true,
+  });
+
+  final bool showManualInput;
 
   @override
   Widget build(BuildContext context) => BlocProvider(
         create: (_) => sl<QrScannerBloc>(),
-        child: const _Content(),
+        child: _Content(showManualInput: showManualInput),
       );
 }
 
 class _Content extends StatefulWidget {
-  const _Content({Key? key}) : super(key: key);
+  const _Content({required this.showManualInput});
+
+  final bool showManualInput;
 
   @override
   State<_Content> createState() => _ContentState();
@@ -144,20 +151,21 @@ class _ContentState extends State<_Content> {
                     alignment: Alignment(0, -0.3),
                     child: _PermissionText(),
                   ),
-                Align(
-                  alignment: Alignment.bottomCenter,
-                  child: SafeArea(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 32.0),
-                      child: CpButton(
-                        text: context.l10n.qrInputAddressTitle,
-                        size: CpButtonSize.big,
-                        minWidth: 250,
-                        onPressed: _onManualInputRequested,
+                if (widget.showManualInput)
+                  Align(
+                    alignment: Alignment.bottomCenter,
+                    child: SafeArea(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 32.0),
+                        child: CpButton(
+                          text: context.l10n.qrInputAddressTitle,
+                          size: CpButtonSize.big,
+                          minWidth: 250,
+                          onPressed: _onManualInputRequested,
+                        ),
                       ),
                     ),
                   ),
-                ),
                 Align(
                   alignment: Alignment.topRight,
                   child: IconButton(

--- a/packages/espressocash_app/lib/features/qr_scanner/widgets/build_context_ext.dart
+++ b/packages/espressocash_app/lib/features/qr_scanner/widgets/build_context_ext.dart
@@ -26,7 +26,7 @@ extension BuilContextExt on BuildContext {
     required CryptoCurrency cryptoCurrency,
     FiatAmount? defaultFiatAmount,
   }) async {
-    final request = await router.push<QrScannerRequest>(const QrScannerRoute());
+    final request = await router.push<QrScannerRequest>(QrScannerRoute());
 
     if (request == null) return;
     if (!mounted) return;


### PR DESCRIPTION
## Changes

Send manually button is not shown when the user open the scanner after the first QR code is scanned.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
