### PR TITLE
fix: correctly sign old cancellation tx

### DIFF
--- a/packages/espressocash_app/lib/features/outgoing_split_key_payments/src/bl/oskp_service.dart
+++ b/packages/espressocash_app/lib/features/outgoing_split_key_payments/src/bl/oskp_service.dart
@@ -157,6 +157,7 @@ class OSKPService {
 
       final String transaction;
       final BigInt slot;
+      final SignedTx tx;
 
       switch (apiVersion) {
         case SplitKeyApiVersion.manual:
@@ -168,16 +169,19 @@ class OSKPService {
           final response = await _client.receivePayment(dto);
           transaction = response.transaction;
           slot = response.slot;
+          tx = await transaction
+              .let(SignedTx.decode)
+              .let((it) => it.resign(LocalWallet(escrow)));
           break;
         case SplitKeyApiVersion.smartContract:
           final response = await _client.cancelPaymentEc(dto);
           transaction = response.transaction;
           slot = response.slot;
+          tx = await transaction
+              .let(SignedTx.decode)
+              .let((it) => it.resign(account));
           break;
       }
-      final tx = await transaction
-          .let(SignedTx.decode)
-          .let((it) => it.resign(account));
 
       return OSKPStatus.cancelTxCreated(
         tx,


### PR DESCRIPTION
## Changes

Manual cancellation tx should be signed with escrow key.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
