### PR TITLE
feat: truncate usdc amount on messages

### DIFF
--- a/packages/espressocash_app/lib/core/presentation/format_amount.dart
+++ b/packages/espressocash_app/lib/core/presentation/format_amount.dart
@@ -9,11 +9,12 @@ import '../currency.dart';
 
 extension FormatAmountWithFiatExt on CryptoAmount {
   String formatWithFiat(BuildContext context) {
+    const fiat = Currency.usd;
     final locale = DeviceLocale.localeOf(context);
-    final formattedAmount = format(locale);
+    final formattedAmount = format(locale, maxDecimals: fiat.decimals);
     final conversionRate = context.watchConversionRate(
       from: cryptoCurrency.token,
-      to: Currency.usd,
+      to: fiat,
     );
     if (conversionRate == null) return formattedAmount;
 


### PR DESCRIPTION
## Changes

- Sets max digits to crypto amount when formatted 

<details><summary>Screenshot</summary>

![Simulator Screenshot - iPhone SE (3rd generation) - 2023-04-29 at 21 51 27](https://user-images.githubusercontent.com/19499575/235330511-73965c18-7932-4ec0-80d8-4be60572a68c.png)

![Simulator Screenshot - iPhone SE (3rd generation) - 2023-04-29 at 21 51 34](https://user-images.githubusercontent.com/19499575/235330513-f50178f5-53bc-4392-a051-293aaabf08e9.png)

</details>

## Related issues

Fixes #956 

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
