### PR TITLE
feat: add coingecko l10n support for token details page

### DIFF
--- a/packages/espressocash_app/lib/features/token_details/src/repository.dart
+++ b/packages/espressocash_app/lib/features/token_details/src/repository.dart
@@ -20,7 +20,7 @@ class TokenDetailsRepository {
       _coingeckoClient
           .getCoinDetails(
             token.extensions?.coingeckoId ?? token.name,
-            const TokenDetailsRequestDto(marketData: true),
+            const TokenDetailsRequestDto(marketData: true, localization: true),
           )
           .toEither()
           .mapAsync((response) {
@@ -28,7 +28,10 @@ class TokenDetailsRepository {
 
         return TokenDetails(
           name: response.name ?? token.name,
-          description: _removeHtmlTags(response.description?['en'] ?? ''),
+          descriptions: response.description?.map(
+            (k, v) => MapEntry(k, _removeHtmlTags(v)),
+            ifRemove: (k, v) => v.isEmpty,
+          ),
           marketCapRank: response.marketCapRank,
           marketPrice: marketData?[fiatCurrency],
         );

--- a/packages/espressocash_app/lib/features/token_details/src/token_details.dart
+++ b/packages/espressocash_app/lib/features/token_details/src/token_details.dart
@@ -1,3 +1,4 @@
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'token_details.freezed.dart';
@@ -6,7 +7,7 @@ part 'token_details.freezed.dart';
 class TokenDetails with _$TokenDetails {
   const factory TokenDetails({
     required String name,
-    required String description,
+    IMap<String, String>? descriptions,
     double? marketPrice,
     int? marketCapRank,
   }) = _TokenDetails;

--- a/packages/espressocash_app/lib/features/token_details/src/widgets/token_details_widget.dart
+++ b/packages/espressocash_app/lib/features/token_details/src/widgets/token_details_widget.dart
@@ -1,5 +1,7 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
+import '../../../../l10n/device_locale.dart';
 import '../../../../l10n/l10n.dart';
 import '../token_details.dart';
 import 'expandable_text.dart';
@@ -25,7 +27,7 @@ class TokenDetailsWidget extends StatelessWidget {
             const SizedBox(height: 12),
             ExpandableText(
               text: TextSpan(
-                text: data.description,
+                text: data.localizedDescription(context),
                 style: const TextStyle(
                   fontWeight: FontWeight.w400,
                   fontSize: 15,
@@ -69,4 +71,18 @@ class _DetailsRowItem extends StatelessWidget {
           ),
         ],
       );
+}
+
+extension on TokenDetails {
+  String localizedDescription(BuildContext context) {
+    final descriptions = this.descriptions;
+    if (descriptions == null) return context.l10n.failedToLoadDescription;
+
+    final languageCode = DeviceLocale.localeOf(context).languageCode;
+
+    return descriptions[languageCode] ??
+        descriptions['en'] ??
+        descriptions.values.firstOrNull ??
+        '';
+  }
 }

--- a/packages/espressocash_app/lib/features/token_details/widgets/token_details_screen.dart
+++ b/packages/espressocash_app/lib/features/token_details/widgets/token_details_screen.dart
@@ -131,11 +131,7 @@ class _Content extends StatelessWidget {
             initial: () => loader,
             processing: () => loader,
             failure: (_) => TokenDetailsWidget(
-              data: TokenDetails(
-                name: token.name,
-                description: context.l10n.failedToLoadDescription,
-                marketCapRank: null,
-              ),
+              data: TokenDetails(name: token.name),
             ),
             success: (data) => TokenDetailsWidget(data: data),
           );


### PR DESCRIPTION
## Changes

- Add l10n support for token details page

**Note**: Coingecko returns an English description for most of keys in the token description object, so localization won't be effective either way in many cases.

<details><summary>Screenshot</summary>

![Captura de Tela 2023-05-07 às 05 08 38](https://user-images.githubusercontent.com/19499575/236666365-12737879-5683-4541-94af-2a9136d02de1.png)

</details>


## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
