### PR TITLE
fix: getFeeForMessage response parsing

### DIFF
--- a/packages/solana/lib/src/rpc/client.dart
+++ b/packages/solana/lib/src/rpc/client.dart
@@ -202,6 +202,7 @@ abstract class RpcClient {
   /// [see this document]: https://docs.solana.com/developing/clients/jsonrpc-api#configuring-state-commitment
   ///
   /// [minContextSlot] Set the minimum slot that the request can be evaluated at.
+  @WithContextResult()
   Future<int?> getFeeForMessage(
     String message, {
     Commitment? commitment,

--- a/packages/solana/lib/src/rpc/client.rpc.dart
+++ b/packages/solana/lib/src/rpc/client.rpc.dart
@@ -243,7 +243,7 @@ class _RpcClient implements RpcClient {
         if (config.isNotEmpty) config,
       ],
     );
-    final dynamic value = getResult(response);
+    final dynamic value = unwrapAndGetResult(response);
 
     return (value == null) ? null : value as int;
   }


### PR DESCRIPTION
## Changes

Currently, getFeeForMessage throws an exception when the result comes back. The response isn't being parsed correctly. This patch fixes this issue and returns the correct fee value integer

## Related issues

Fixes #___

## Checklist

- [ ] PR is ready for review (if not, it should be a draft).
- [ ] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [ ] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
