### PR TITLE
fix: remove home tab animation transition

### DIFF
--- a/packages/espressocash_app/lib/features/authenticated/screens/home_screen.dart
+++ b/packages/espressocash_app/lib/features/authenticated/screens/home_screen.dart
@@ -18,6 +18,7 @@ class HomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => AutoTabsRouter(
+        duration: Duration.zero,
         routes: _pages.map((e) => e.route).toList(),
         builder: (context, child) {
           final tabsRouter = AutoTabsRouter.of(context);


### PR DESCRIPTION
## Changes

remove page transition animation on home screens

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
