### PR TITLE
feat: redirect after kado onramp

### DIFF
--- a/packages/espressocash_app/lib/features/ramp/src/widgets/partners/kado.dart
+++ b/packages/espressocash_app/lib/features/ramp/src/widgets/partners/kado.dart
@@ -13,6 +13,7 @@ import '../../../data/on_ramp_order_service.dart';
 import '../../../kado/data/kado_api_client.dart';
 import '../../../models/ramp_partner.dart';
 import '../../../screens/off_ramp_order_screen.dart';
+import '../../../screens/on_ramp_order_screen.dart';
 import '../../../services/off_ramp_order_service.dart';
 import '../../models/profile_data.dart';
 import '../../models/ramp_type.dart';
@@ -70,11 +71,20 @@ extension BuildContextExt on BuildContext {
                 'type': 'RAMP_ORDER_ID',
                 'payload': {'orderId': final String orderId}
               }) {
-            sl<OnRampOrderService>().create(
+            sl<OnRampOrderService>()
+                .create(
               orderId: orderId,
               amount: submittedAmount,
               partner: RampPartner.kado,
-            );
+            )
+                .then((order) {
+              switch (order) {
+                case Left<Exception, String>():
+                  break;
+                case Right<Exception, String>(:final value):
+                  router.replace(OnRampOrderScreen.route(orderId: value));
+              }
+            });
             orderWasCreated = true;
           }
         },


### PR DESCRIPTION
## Changes

redirect to on ramp status screen after kado onramp

## Videos
<details>

https://github.com/espresso-cash/espresso-cash-public/assets/28533130/f5d5fc9c-cc88-45e5-92a0-50d5254250ba

</details>

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
