### PR TITLE
feat: make Jupiter API configurable via ENV vars

### DIFF
--- a/packages/jupiter_aggregator/README.md
+++ b/packages/jupiter_aggregator/README.md
@@ -28,8 +28,10 @@ start using the package.
 Define environmental variables when launching the app with flags on the command line. For example:
 
 ```bash
-flutter run lib/main.dart --dart-define=QUOTE_API_BASE=https://quote-api.jup.ag/v6
+flutter run lib/main.dart --dart-define=QUOTE_API_BASE=https://public.jupiterapi.com
 ```
+
+You can get Swap API urls from [Jupiter Station](https://station.jup.ag/docs/apis/swap-api), [QuickNode](https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api) or [JupiterAPI.com](https://www.jupiterapi.com/).
 
 ## Additional information
 

--- a/packages/jupiter_aggregator/README.md
+++ b/packages/jupiter_aggregator/README.md
@@ -25,11 +25,10 @@ start using the package.
 
 ## Usage
 
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder. 
+Define environmental variables when launching the app with flags on the command line. For example:
 
-```dart
-const like = 'sample';
+```bash
+flutter run lib/main.dart --dart-define=QUOTE_API_BASE=https://quote-api.jup.ag/v6
 ```
 
 ## Additional information

--- a/packages/jupiter_aggregator/lib/src/client.dart
+++ b/packages/jupiter_aggregator/lib/src/client.dart
@@ -7,7 +7,7 @@ import 'package:retrofit/retrofit.dart';
 part 'client.g.dart';
 
 /// For docs head to https://station.jup.ag/api-v6
-@RestApi(baseUrl: String.fromEnvironment('QUOTE_API_BASE', defaultValue: 'https://public.jupiterapi.com',))
+@RestApi(baseUrl: String.fromEnvironment('QUOTE_API_BASE', defaultValue: 'https://quote-api.jup.ag/v6',))
 abstract class JupiterAggregatorClient {
   factory JupiterAggregatorClient() => _JupiterAggregatorClient(Dio());
 

--- a/packages/jupiter_aggregator/lib/src/client.dart
+++ b/packages/jupiter_aggregator/lib/src/client.dart
@@ -7,7 +7,7 @@ import 'package:retrofit/retrofit.dart';
 part 'client.g.dart';
 
 /// For docs head to https://station.jup.ag/api-v6
-@RestApi(baseUrl: 'https://quote-api.jup.ag/v6')
+@RestApi(baseUrl: String.fromEnvironment('QUOTE_API_BASE', defaultValue: 'https://public.jupiterapi.com',))
 abstract class JupiterAggregatorClient {
   factory JupiterAggregatorClient() => _JupiterAggregatorClient(Dio());
 

--- a/packages/jupiter_aggregator/lib/src/client.dart
+++ b/packages/jupiter_aggregator/lib/src/client.dart
@@ -9,7 +9,8 @@ part 'client.g.dart';
 /// For docs head to https://station.jup.ag/api-v6
 @RestApi(
     baseUrl: String.fromEnvironment('QUOTE_API_BASE',
-        defaultValue: 'https://quote-api.jup.ag/v6'))
+    defaultValue: 'https://quote-api.jup.ag/v6'),
+)
 abstract class JupiterAggregatorClient {
   factory JupiterAggregatorClient() => _JupiterAggregatorClient(Dio());
 

--- a/packages/jupiter_aggregator/lib/src/client.dart
+++ b/packages/jupiter_aggregator/lib/src/client.dart
@@ -8,8 +8,10 @@ part 'client.g.dart';
 
 /// For docs head to https://station.jup.ag/api-v6
 @RestApi(
-    baseUrl: String.fromEnvironment('QUOTE_API_BASE',
-    defaultValue: 'https://quote-api.jup.ag/v6'),
+  baseUrl: String.fromEnvironment(
+    'QUOTE_API_BASE',
+    defaultValue: 'https://quote-api.jup.ag/v6',
+  ),
 )
 abstract class JupiterAggregatorClient {
   factory JupiterAggregatorClient() => _JupiterAggregatorClient(Dio());

--- a/packages/jupiter_aggregator/lib/src/client.dart
+++ b/packages/jupiter_aggregator/lib/src/client.dart
@@ -7,7 +7,9 @@ import 'package:retrofit/retrofit.dart';
 part 'client.g.dart';
 
 /// For docs head to https://station.jup.ag/api-v6
-@RestApi(baseUrl: String.fromEnvironment('QUOTE_API_BASE', defaultValue: 'https://quote-api.jup.ag/v6',))
+@RestApi(
+    baseUrl: String.fromEnvironment('QUOTE_API_BASE',
+        defaultValue: 'https://quote-api.jup.ag/v6'))
 abstract class JupiterAggregatorClient {
   factory JupiterAggregatorClient() => _JupiterAggregatorClient(Dio());
 

--- a/packages/jupiter_aggregator/lib/src/client.g.dart
+++ b/packages/jupiter_aggregator/lib/src/client.g.dart
@@ -13,7 +13,10 @@ class _JupiterAggregatorClient implements JupiterAggregatorClient {
     this._dio, {
     this.baseUrl,
   }) {
-    baseUrl ??= 'https://quote-api.jup.ag/v6';
+    baseUrl ??= String.fromEnvironment(
+    'QUOTE_API_BASE',
+    defaultValue: 'https://public.jupiterapi.com',
+  );
   }
 
   final Dio _dio;

--- a/packages/jupiter_aggregator/lib/src/client.g.dart
+++ b/packages/jupiter_aggregator/lib/src/client.g.dart
@@ -15,7 +15,7 @@ class _JupiterAggregatorClient implements JupiterAggregatorClient {
   }) {
     baseUrl ??= String.fromEnvironment(
     'QUOTE_API_BASE',
-    defaultValue: 'https://public.jupiterapi.com',
+    defaultValue: 'https://quote-api.jup.ag/v6',
   );
   }
 

--- a/packages/jupiter_aggregator/lib/src/client.g.dart
+++ b/packages/jupiter_aggregator/lib/src/client.g.dart
@@ -14,9 +14,9 @@ class _JupiterAggregatorClient implements JupiterAggregatorClient {
     this.baseUrl,
   }) {
     baseUrl ??= String.fromEnvironment(
-    'QUOTE_API_BASE',
-    defaultValue: 'https://quote-api.jup.ag/v6',
-  );
+      'QUOTE_API_BASE',
+      defaultValue: 'https://quote-api.jup.ag/v6',
+    );
   }
 
   final Dio _dio;


### PR DESCRIPTION
## Changes

1. Makes the Jupiter Swap V6 API base URL configurable.
2. Changes default URL to URL with higher rate limits.
3. Updates the README.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
