### PR TITLE
feat: proxy (Tor/SOCKS5) support: add optional configurable dart:io HttpClient.

### DIFF
--- a/packages/solana/lib/src/rpc/client.dart
+++ b/packages/solana/lib/src/rpc/client.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:solana/encoder.dart';
@@ -18,6 +19,7 @@ abstract class RpcClient {
     String url, {
     Duration timeout = const Duration(seconds: 30),
     Map<String, String> customHeaders = const {},
+    HttpClient? httpClient,
   }) =>
       _RpcClient(
         url,
@@ -25,6 +27,7 @@ abstract class RpcClient {
           url,
           timeout: timeout,
           customHeaders: customHeaders,
+          httpClient: httpClient,
         ),
       );
 

--- a/packages/solana/lib/src/rpc/client.dart
+++ b/packages/solana/lib/src/rpc/client.dart
@@ -18,6 +18,7 @@ abstract class RpcClient {
     String url, {
     Duration timeout = const Duration(seconds: 30),
     Map<String, String> customHeaders = const {},
+    Map<String, dynamic>? proxyInfo, // {host: String, port: int}
   }) =>
       _RpcClient(
         url,
@@ -25,6 +26,7 @@ abstract class RpcClient {
           url,
           timeout: timeout,
           customHeaders: customHeaders,
+          proxyInfo: proxyInfo ?? {},
         ),
       );
 

--- a/packages/solana/lib/src/rpc/client.dart
+++ b/packages/solana/lib/src/rpc/client.dart
@@ -18,7 +18,6 @@ abstract class RpcClient {
     String url, {
     Duration timeout = const Duration(seconds: 30),
     Map<String, String> customHeaders = const {},
-    Map<String, dynamic>? proxyInfo, // {host: String, port: int}
   }) =>
       _RpcClient(
         url,
@@ -26,7 +25,6 @@ abstract class RpcClient {
           url,
           timeout: timeout,
           customHeaders: customHeaders,
-          proxyInfo: proxyInfo ?? {},
         ),
       );
 

--- a/packages/solana/lib/src/rpc/json_rpc_client.dart
+++ b/packages/solana/lib/src/rpc/json_rpc_client.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
-import 'package:http/http.dart';
 import 'package:solana/src/exceptions/http_exception.dart';
 import 'package:solana/src/exceptions/json_rpc_exception.dart';
-import 'package:solana/src/exceptions/rpc_timeout_exception.dart';
 import 'package:solana/src/rpc/json_rpc_request.dart';
 
 class JsonRpcClient {
@@ -12,13 +11,18 @@ class JsonRpcClient {
     this._url, {
     required Duration timeout,
     required Map<String, String> customHeaders,
+    HttpClient? httpClient, // Optional client for proxy support.
   })  : _timeout = timeout,
-        _headers = {..._defaultHeaders, ...customHeaders};
+        _headers = {..._defaultHeaders, ...customHeaders},
+        _httpClient = httpClient ?? HttpClient();
 
   final String _url;
   final Duration _timeout;
   final Map<String, String> _headers;
+  final HttpClient _httpClient;
   int _lastId = 1;
+
+  static get http => null;
 
   Future<List<Map<String, dynamic>>> bulkRequest(
     String method,
@@ -65,29 +69,23 @@ class JsonRpcClient {
     throw const FormatException('unexpected jsonrpc response type');
   }
 
+  /// Sends a POST request to the server.
   Future<_JsonRpcResponse> _postRequest(
     JsonRpcRequest request,
   ) async {
     final body = request.toJson();
     // Perform the POST request
-    final Response response = await post(
-      Uri.parse(_url),
-      headers: _headers,
-      body: json.encode(body),
-    ).timeout(
-      _timeout,
-      onTimeout: () => throw RpcTimeoutException(
-        method: request.method,
-        body: body,
-        timeout: _timeout,
-      ),
-    );
+    final HttpClientRequest httpRequest =
+        await _httpClient.postUrl(Uri.parse(_url));
+    _headers.forEach((key, value) => httpRequest.headers.add(key, value));
+    httpRequest.write(json.encode(body));
     // Handle the response
-    if (response.statusCode == 200) {
-      return _JsonRpcResponse._parse(json.decode(response.body));
+    final HttpClientResponse httpResponse = await httpRequest.close();
+    final responseBody = await httpResponse.transform(utf8.decoder).join();
+    if (httpResponse.statusCode == 200) {
+      return _JsonRpcResponse._parse(json.decode(responseBody));
     }
-
-    throw HttpException(response.statusCode, response.body);
+    throw HttpException(httpResponse.statusCode, responseBody);
   }
 }
 

--- a/packages/solana/lib/src/rpc/json_rpc_client.dart
+++ b/packages/solana/lib/src/rpc/json_rpc_client.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
 
-import 'package:http/http.dart';
+import 'package:socks5_proxy/socks.dart';
 import 'package:solana/src/exceptions/http_exception.dart';
 import 'package:solana/src/exceptions/json_rpc_exception.dart';
 import 'package:solana/src/exceptions/rpc_timeout_exception.dart';
@@ -12,12 +14,15 @@ class JsonRpcClient {
     this._url, {
     required Duration timeout,
     required Map<String, String> customHeaders,
+    required Map<String, dynamic> proxyInfo, // {host: String, port: int}
   })  : _timeout = timeout,
-        _headers = {..._defaultHeaders, ...customHeaders};
+        _headers = {..._defaultHeaders, ...customHeaders},
+        _proxyInfo = proxyInfo;
 
   final String _url;
   final Duration _timeout;
   final Map<String, String> _headers;
+  final Map<String, dynamic> _proxyInfo;
   int _lastId = 1;
 
   Future<List<Map<String, dynamic>>> bulkRequest(
@@ -68,26 +73,51 @@ class JsonRpcClient {
   Future<_JsonRpcResponse> _postRequest(
     JsonRpcRequest request,
   ) async {
-    final body = request.toJson();
-    // Perform the POST request
-    final Response response = await post(
-      Uri.parse(_url),
-      headers: _headers,
-      body: json.encode(body),
-    ).timeout(
-      _timeout,
-      onTimeout: () => throw RpcTimeoutException(
-        method: request.method,
-        body: body,
-        timeout: _timeout,
-      ),
-    );
-    // Handle the response
-    if (response.statusCode == 200) {
-      return _JsonRpcResponse._parse(json.decode(response.body));
-    }
+    final Uri uri = Uri.parse(_url);
+    final HttpClient httpClient = HttpClient();
 
-    throw HttpException(response.statusCode, response.body);
+    try {
+      // If proxyInfo is provided, configure the proxy.
+      if (_proxyInfo.isNotEmpty) {
+        SocksTCPClient.assignToHttpClient(httpClient, [
+          ProxySettings(
+            InternetAddress(_proxyInfo['host'] as String),
+            _proxyInfo['port'] as int,
+          ),
+        ]);
+      }
+
+      final HttpClientRequest httpClientRequest = await httpClient.postUrl(uri);
+      _headers
+          .forEach((key, value) => httpClientRequest.headers.set(key, value));
+      httpClientRequest.write(json.encode(request.toJson()));
+
+      final HttpClientResponse response =
+          await httpClientRequest.close().timeout(
+        _timeout,
+        onTimeout: () {
+          throw RpcTimeoutException(
+            method: request.method,
+            body: json.encode(request.toJson()),
+            timeout: _timeout,
+          );
+        },
+      );
+
+      // Consolidate the bytes and parse the response.
+      final Uint8List bodyBytes =
+          await consolidateHttpClientResponseBytes(response);
+      final String responseBody = utf8.decode(bodyBytes);
+      final int statusCode = response.statusCode;
+
+      if (statusCode == 200) {
+        return _JsonRpcResponse._parse(json.decode(responseBody));
+      }
+
+      throw HttpException(statusCode, responseBody);
+    } finally {
+      httpClient.close();
+    }
   }
 }
 
@@ -148,3 +178,21 @@ class _JsonRpcArrayResponse implements _JsonRpcResponse {
 const _defaultHeaders = <String, String>{
   'Content-Type': 'application/json',
 };
+
+/// Helper function to consolidate HttpClientResponse bytes.
+///
+/// Helps ensure HttpClientResponse is fully read before closing the connection.
+/// Helper for proxied connections.
+Future<Uint8List> consolidateHttpClientResponseBytes(
+    HttpClientResponse response) {
+  final Completer<Uint8List> completer = Completer<Uint8List>();
+  final List<int> bytes = [];
+  response.listen(
+    bytes.addAll,
+    onDone: () => completer.complete(Uint8List.fromList(bytes)),
+    onError: completer.completeError,
+    cancelOnError: true,
+  );
+
+  return completer.future;
+}

--- a/packages/solana/pubspec.yaml
+++ b/packages/solana/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   freezed_annotation: ^2.0.0
   http: ^1.1.0
   json_annotation: ^4.4.0
+  socks5_proxy: ^1.0.4
   typed_data: ^1.3.0
   web_socket_channel: ^2.1.0
 

--- a/packages/solana/pubspec.yaml
+++ b/packages/solana/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   freezed_annotation: ^2.0.0
   http: ^1.1.0
   json_annotation: ^4.4.0
-  socks5_proxy: ^1.0.4
   typed_data: ^1.3.0
   web_socket_channel: ^2.1.0
 


### PR DESCRIPTION
Closes #1382.

Adds an optional `HttpClient httpClient` property (from `dart:io) to a Solana RpcClient (and JsonRpcClient).  If it's null (as old clients will pass it by default), it changes no behavior.  If it's not null, it uses the provided HttpClient to proxy requests.

You can see an example of usage in Stack Wallet at https://github.com/cypherstack/stack_wallet/blob/2feb7d0be3fb85c6db270f2a12f0ef8e5ef0334d/lib/wallets/wallet/impl/solana_wallet.dart#L419

See https://github.com/espresso-cash/espresso-cash-public/pull/1378 and https://github.com/espresso-cash/espresso-cash-public/pull/1383 for previous description and discussion.

Thank you @ookami-kb for your guidance through this process!  I'm happy that Stack Wallet doesn't have to be the only Solana wallet which can proxy request through a SOCKS5 proxy like Tor.  See https://github.com/Foundation-Devices/tor for an easy-to-use embeddable Tor proxy which uses the Tor project's `arti` (A Rust Tor Implementation).

## Changes

- Alter the `RpcClient` and `JsonRpcClient` classes and the `_postRequest` method in order to optionally support proxied HttpClients.

## Related issues

- Fixes #1382
- Fixes #1377 

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video not applicable.
- [x] Tests unaffected.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
