### PR TITLE
fix: show proper tx status for common tile

### DIFF
--- a/packages/espressocash_app/lib/features/activities/widgets/common_tile.dart
+++ b/packages/espressocash_app/lib/features/activities/widgets/common_tile.dart
@@ -22,14 +22,19 @@ class CommonTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final signature = txCommon.tx.id;
 
-    final isOutgoing = txCommon.amount?.let((e) => e.value.isNegative) ?? false;
+    final isOutgoing =
+        txCommon.amount?.let((e) => e.value.isNegative || e.value == 0) ??
+            false;
     final amount = txCommon.amount
         ?.let((e) => e.format(context.locale, maxDecimals: 2))
         .let((e) => e.replaceAll('-', ''));
 
     return CpActivityTile(
       title: signature.toShortAddress(),
-      status: CpActivityTileStatus.success,
+      status: switch (txCommon.status) {
+        TxCommonStatus.success => CpActivityTileStatus.success,
+        TxCommonStatus.failure => CpActivityTileStatus.failure,
+      },
       timestamp: txCommon.created?.let(context.formatDate) ?? '',
       outgoingAmount: isOutgoing ? amount : null,
       incomingAmount: isOutgoing ? null : amount,


### PR DESCRIPTION
## Changes

- show proper tx status in common tile
- use black text for 0 amount tiles

## Related issues

Fixes #1439

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
