### PR TITLE
feat: add ignoreSignerVerification on processSolanaPayTransactionRequest

### DIFF
--- a/packages/solana/lib/src/solana_pay/solana_client_ext.dart
+++ b/packages/solana/lib/src/solana_pay/solana_client_ext.dart
@@ -294,7 +294,7 @@ extension SolanaClientSolanaPay on SolanaClient {
   /// Commitment is used when getting latest blockhash.
   ///
   /// If [ignoreSignerVerification] is true, signature verification will be
-  /// skipped for the signer. Only applies when the transaction signatures are nonempty
+  /// skipped for [signer]. Only applies when the transaction signatures are nonempty
   ///
   /// [1]: https://github.com/solana-labs/solana-pay/blob/master/SPEC.md#link
   /// [2]: https://github.com/solana-labs/solana-pay/blob/master/SPEC.md#post-request

--- a/packages/solana/lib/src/solana_pay/solana_client_ext.dart
+++ b/packages/solana/lib/src/solana_pay/solana_client_ext.dart
@@ -293,12 +293,16 @@ extension SolanaClientSolanaPay on SolanaClient {
   ///
   /// Commitment is used when getting latest blockhash.
   ///
+  /// If [ignoreSignerVerification] is true, signature verification will be
+  /// skipped for the signer. Only applies when the transaction signatures are nonempty
+  ///
   /// [1]: https://github.com/solana-labs/solana-pay/blob/master/SPEC.md#link
   /// [2]: https://github.com/solana-labs/solana-pay/blob/master/SPEC.md#post-request
   Future<SignedTx> processSolanaPayTransactionRequest({
     required String transaction,
     required Ed25519HDPublicKey signer,
     Commitment commitment = Commitment.finalized,
+    bool ignoreSignerVerification = false,
   }) async {
     final tx = SignedTx.decode(transaction);
 
@@ -348,6 +352,10 @@ extension SolanaClientSolanaPay on SolanaClient {
       for (final sig in signatures) {
         final signature = sig.bytes;
         final publicKey = sig.publicKey;
+
+        if (ignoreSignerVerification && publicKey == signer) {
+          continue;
+        }
 
         final isValid = await verifySignature(
           message: compiledMessage.toByteArray().toList(),


### PR DESCRIPTION
## Changes

adds ignoreSignerVerification on processSolanaPayTransactionRequest. used when wallet has not resigned the tx prior to validation 

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
