### PR TITLE
fix: activity tile text color to white

### DIFF
--- a/packages/espressocash_app/lib/features/activities/widgets/activity_tile.dart
+++ b/packages/espressocash_app/lib/features/activities/widgets/activity_tile.dart
@@ -76,7 +76,7 @@ class CpActivityTile extends StatelessWidget {
 const _titleStyle = TextStyle(
   fontSize: 16,
   letterSpacing: .23,
-  color: CpColors.lightGreyBackground,
+  color: Colors.white,
   fontWeight: FontWeight.w600,
 );
 
@@ -89,7 +89,7 @@ const _inAmountStyle = TextStyle(
 
 const _subtitleStyle = TextStyle(
   fontSize: 14,
-  color: CpColors.secondaryTextColor,
+  color: Colors.white,
   letterSpacing: .19,
 );
 


### PR DESCRIPTION
## Changes

Changed ActivityScreen tile text color to white.

## Related issues

Fixes #1474 

<details>
<summary>Screenshots</summary>
<br>

![84654e66-ebcc-4b1c-9a3e-930b06a4efa5](https://github.com/espresso-cash/espresso-cash-public/assets/17258221/75bc7f51-9d52-4152-959f-c338af8d611b)

</details>

## Checklist

- [ ] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
