### PR TITLE
fix: sol conversion matching

### DIFF
--- a/packages/espressocash_app/lib/features/conversion_rates/data/repository.dart
+++ b/packages/espressocash_app/lib/features/conversion_rates/data/repository.dart
@@ -92,12 +92,16 @@ class ConversionRatesRepository extends ChangeNotifier {
               if (data == null) return map;
               final rate = data.price * usdcRate;
 
-              return map.add(
-                CryptoCurrency(
-                  token: tokens.firstWhere((t) => t.symbol == value),
-                ),
-                Decimal.parse(rate.toString()),
-              );
+              final matchingTokens = tokens.where((t) => t.symbol == value);
+
+              for (final token in matchingTokens) {
+                map = map.add(
+                  CryptoCurrency(token: token),
+                  Decimal.parse(rate.toString()),
+                );
+              }
+
+              return map;
             }),
           ),
         );


### PR DESCRIPTION
## Changes

fixes wrong SOL amount. happens when user has sol and wrapped sol, only matching first on either.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
