### PR TITLE
fix: ReturnData serialization

### DIFF
--- a/packages/solana/lib/src/rpc/dto/return_data.dart
+++ b/packages/solana/lib/src/rpc/dto/return_data.dart
@@ -17,7 +17,22 @@ class ReturnData {
   final String programId;
 
   /// The return data itself, as base-64 encoded binary data
+  @JsonKey(fromJson: _dataFromJson, toJson: _dataToJson)
   final String data;
 
   Map<String, dynamic> toJson() => _$ReturnDataToJson(this);
+
+  static List<String> _dataToJson(String data) => [data, 'base64'];
+
+  static String _dataFromJson(dynamic data) {
+    if (data is String) {
+      return data;
+    } else if (data is List<String> &&
+        data.length == 2 &&
+        data[1] == 'base64') {
+      return data[0];
+    }
+
+    throw ArgumentError.value(data, 'data', 'Invalid data type');
+  }
 }

--- a/packages/solana/lib/src/rpc/dto/return_data.g.dart
+++ b/packages/solana/lib/src/rpc/dto/return_data.g.dart
@@ -8,11 +8,11 @@ part of 'return_data.dart';
 
 ReturnData _$ReturnDataFromJson(Map<String, dynamic> json) => ReturnData(
       programId: json['programId'] as String,
-      data: json['data'] as String,
+      data: ReturnData._dataFromJson(json['data']),
     );
 
 Map<String, dynamic> _$ReturnDataToJson(ReturnData instance) =>
     <String, dynamic>{
       'programId': instance.programId,
-      'data': instance.data,
+      'data': ReturnData._dataToJson(instance.data),
     };


### PR DESCRIPTION
## Changes

Update `ReturnData` serialization to accept both `'data'` and `['data', 'base64']`.

## Related issues

Fixes #1460

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
