### PR TITLE
ci: update upload-artifact

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -200,7 +200,7 @@ jobs:
 
       - name: Store failure artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: golden-test-failure
           path: "**/test/golden/**/failures/"
@@ -252,7 +252,7 @@ jobs:
 
       - name: Store failure artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: golden-test-failure
           path: "**/test/golden/**/failures/"


### PR DESCRIPTION
## Changes

updates deprecated upload-artifact version (https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
