### PR TITLE
fix: pass tokenProgramId to createAccount method in createAssociatedTokenAccount

### DIFF
--- a/packages/solana/lib/src/programs/associated_token_account_program/solana_client_ext.dart
+++ b/packages/solana/lib/src/programs/associated_token_account_program/solana_client_ext.dart
@@ -66,6 +66,7 @@ extension SolanaClientAssociatedTokenAccontProgram on SolanaClient {
       address: derivedAddress,
       owner: effectiveOwner,
       funder: funder.publicKey,
+      tokenProgramId: tokenProgramType.id,
     );
 
     await sendAndConfirmTransaction(


### PR DESCRIPTION
## Changes

- pass the tokenProgramId to the createAccount method in the createAssociatedTokenAccount method.

## Related issues
Related to: https://github.com/espresso-cash/espresso-cash-public/issues/1657

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
