### PR TITLE
Update web_socket_channel dependency to version ^3.0.1

### DIFF
--- a/packages/solana/pubspec.yaml
+++ b/packages/solana/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   http: ^1.1.0
   json_annotation: ^4.4.0
   typed_data: ^1.3.0
-  web_socket_channel: ^3.0.0
+  web_socket_channel: ^3.0.1
 
 dev_dependencies:
   borsh: ^0.3.1+4


### PR DESCRIPTION
Fixes #1658

Update the `web_socket_channel` dependency to version `^3.0.1` in `packages/solana/pubspec.yaml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/espresso-cash/espresso-cash-public/pull/1662?shareId=963595a9-7467-441c-8823-46b2d1b9e508).