### PR TITLE
fix: transferSplToken not supporting different program types

### DIFF
--- a/packages/solana/lib/src/programs/token_program/solana_client_ext.dart
+++ b/packages/solana/lib/src/programs/token_program/solana_client_ext.dart
@@ -131,6 +131,7 @@ extension SolanaClientTokenProgram on SolanaClient {
     String? memo,
     SignatureCallback? onSigned,
     Commitment commitment = Commitment.finalized,
+    TokenProgramType tokenProgramType = TokenProgramType.tokenProgram,
   }) async {
     final associatedRecipientAccount = await getAssociatedTokenAccount(
       owner: destination,
@@ -162,6 +163,7 @@ extension SolanaClientTokenProgram on SolanaClient {
           Ed25519HDPublicKey.fromBase58(associatedRecipientAccount.pubkey),
       owner: owner.publicKey,
       amount: amount,
+      tokenProgram: tokenProgramType,
     );
 
     final message = Message(

--- a/packages/solana/lib/src/programs/token_program/solana_client_ext.dart
+++ b/packages/solana/lib/src/programs/token_program/solana_client_ext.dart
@@ -131,7 +131,7 @@ extension SolanaClientTokenProgram on SolanaClient {
     String? memo,
     SignatureCallback? onSigned,
     Commitment commitment = Commitment.finalized,
-    TokenProgramType tokenProgramType = TokenProgramType.tokenProgram,
+    TokenProgramType tokenProgram = TokenProgramType.tokenProgram,
   }) async {
     final associatedRecipientAccount = await getAssociatedTokenAccount(
       owner: destination,
@@ -163,7 +163,7 @@ extension SolanaClientTokenProgram on SolanaClient {
           Ed25519HDPublicKey.fromBase58(associatedRecipientAccount.pubkey),
       owner: owner.publicKey,
       amount: amount,
-      tokenProgram: tokenProgramType,
+      tokenProgram: tokenProgram,
     );
 
     final message = Message(


### PR DESCRIPTION
## Changes

The transferSplToken method doesn't support the token 2022 program. 

## Related issues

Fixes #___

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
