### PR TITLE
feat: Update SDK constraints and upgrade deps

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -9,8 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: "3.24.5"
-  DART_VERSION: "3.5.4"
+  FLUTTER_VERSION: "3.27.4"
+  DART_VERSION: "3.6.2"
   DCM_VERSION: "1.17.0"
 
 jobs:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: "3.24.5"
+  FLUTTER_VERSION: "3.27.4"
 
 jobs:
   e2e:

--- a/.github/workflows/solana_coverage.yml
+++ b/.github/workflows/solana_coverage.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: "3.24.5"
+  FLUTTER_VERSION: "3.27.4"
 
 jobs:
   solana_coverage:

--- a/packages/borsh/pubspec.yaml
+++ b/packages/borsh/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
   Implementation of the borsh serialization scheme
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=2.16.0 <4.0.0"
 
 dependencies:
   analyzer: ">=2.0.0 <6.0.0"

--- a/packages/borsh/pubspec.yaml
+++ b/packages/borsh/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
   Implementation of the borsh serialization scheme
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   analyzer: ">=5.4.0 <8.0.0"

--- a/packages/borsh/pubspec.yaml
+++ b/packages/borsh/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
   Implementation of the borsh serialization scheme
 
 environment:
-  sdk: ">=2.16.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   analyzer: ">=2.0.0 <6.0.0"

--- a/packages/borsh/pubspec.yaml
+++ b/packages/borsh/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=2.0.0 <6.0.0"
+  analyzer: ">=5.4.0 <8.0.0"
   borsh_annotation: ^0.3.1+5
   build: ^2.0.3
   source_gen: ^1.0.3

--- a/packages/borsh/pubspec.yaml
+++ b/packages/borsh/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
   analyzer: ">=5.4.0 <8.0.0"
   borsh_annotation: ^0.3.1+5
   build: ^2.0.3
-  source_gen: ^1.0.3
-  source_helper: ^1.3.2
+  source_gen: ">=1.4.0 <3.0.0"
+  source_helper: ^1.3.4
 
 dev_dependencies:
   build_runner: ^2.0.6

--- a/packages/borsh/pubspec.yaml
+++ b/packages/borsh/pubspec.yaml
@@ -16,5 +16,5 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.6
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
   test: ^1.17.10

--- a/packages/borsh_annotation/pubspec.yaml
+++ b/packages/borsh_annotation/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
   Annotation used to make a Dart object borsh serializable.
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
+  sdk: ">=2.13.0 <4.0.0"
 
 dev_dependencies:
   mews_pedantic: ^0.26.0

--- a/packages/borsh_annotation/pubspec.yaml
+++ b/packages/borsh_annotation/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
   Annotation used to make a Dart object borsh serializable.
 
 environment:
-  sdk: ">=2.13.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
   mews_pedantic: ^0.27.0

--- a/packages/borsh_annotation/pubspec.yaml
+++ b/packages/borsh_annotation/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
   Annotation used to make a Dart object borsh serializable.
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dev_dependencies:
   mews_pedantic: ^0.27.0

--- a/packages/borsh_annotation/pubspec.yaml
+++ b/packages/borsh_annotation/pubspec.yaml
@@ -8,4 +8,4 @@ environment:
   sdk: ">=2.13.0 <4.0.0"
 
 dev_dependencies:
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0

--- a/packages/espressocash_api/lib/src/client.g.dart
+++ b/packages/espressocash_api/lib/src/client.g.dart
@@ -6,13 +6,10 @@ part of 'client.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
 class _EspressoCashClient implements EspressoCashClient {
-  _EspressoCashClient(
-    this._dio, {
-    this.baseUrl,
-  }) {
+  _EspressoCashClient(this._dio, {this.baseUrl, this.errorLogger}) {
     baseUrl ??= 'https://api.espressocash.com/api/v1';
   }
 
@@ -20,33 +17,36 @@ class _EspressoCashClient implements EspressoCashClient {
 
   String? baseUrl;
 
+  final ParseErrorLogger? errorLogger;
+
   @override
   Future<CreateDirectPaymentResponseDto> createDirectPayment(
-      CreateDirectPaymentRequestDto request) async {
+    CreateDirectPaymentRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<CreateDirectPaymentResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/createDirectPayment',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = CreateDirectPaymentResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<CreateDirectPaymentResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/createDirectPayment',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late CreateDirectPaymentResponseDto _value;
+    try {
+      _value = CreateDirectPaymentResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -55,25 +55,25 @@ class _EspressoCashClient implements EspressoCashClient {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio
-        .fetch<Map<String, dynamic>>(_setStreamType<GetFeesResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/getFees',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = GetFeesResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<GetFeesResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/getFees',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late GetFeesResponseDto _value;
+    try {
+      _value = GetFeesResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -83,199 +83,205 @@ class _EspressoCashClient implements EspressoCashClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<SwapRouteResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/getSwapRoute',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = SwapRouteResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<SwapRouteResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/getSwapRoute',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late SwapRouteResponseDto _value;
+    try {
+      _value = SwapRouteResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<CreatePaymentResponseDto> createPaymentEc(
-      CreatePaymentRequestDto request) async {
+    CreatePaymentRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<CreatePaymentResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/escrow/create',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = CreatePaymentResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<CreatePaymentResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/escrow/create',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late CreatePaymentResponseDto _value;
+    try {
+      _value = CreatePaymentResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<ReceivePaymentResponseDto> receivePaymentEc(
-      ReceivePaymentRequestDto request) async {
+    ReceivePaymentRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<ReceivePaymentResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/escrow/receive',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = ReceivePaymentResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ReceivePaymentResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/escrow/receive',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ReceivePaymentResponseDto _value;
+    try {
+      _value = ReceivePaymentResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<CancelPaymentResponseDto> cancelPaymentEc(
-      CancelPaymentRequestDto request) async {
+    CancelPaymentRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<CancelPaymentResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/escrow/cancel',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = CancelPaymentResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<CancelPaymentResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/escrow/cancel',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late CancelPaymentResponseDto _value;
+    try {
+      _value = CancelPaymentResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<GenerateScalexLinkResponseDto> generateScalexLink(
-      GenerateScalexLinkRequestDto request) async {
+    GenerateScalexLinkRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<GenerateScalexLinkResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/scalex/generate',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = GenerateScalexLinkResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<GenerateScalexLinkResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/scalex/generate',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late GenerateScalexLinkResponseDto _value;
+    try {
+      _value = GenerateScalexLinkResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<OrderStatusScalexResponseDto> fetchScalexTransaction(
-      OrderStatusScalexRequestDto referenceId) async {
+    OrderStatusScalexRequestDto referenceId,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(referenceId.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<OrderStatusScalexResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/scalex/fetch',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = OrderStatusScalexResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<OrderStatusScalexResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/scalex/fetch',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late OrderStatusScalexResponseDto _value;
+    try {
+      _value = OrderStatusScalexResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<ScalexWithdrawResponseDto> createScalexWithdraw(
-      ScalexWithdrawRequestDto request) async {
+    ScalexWithdrawRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<ScalexWithdrawResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/scalex/withdraw',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = ScalexWithdrawResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ScalexWithdrawResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/scalex/withdraw',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ScalexWithdrawResponseDto _value;
+    try {
+      _value = ScalexWithdrawResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -284,54 +290,55 @@ class _EspressoCashClient implements EspressoCashClient {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<ScalexRateFeeResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/scalex/fees',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = ScalexRateFeeResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ScalexRateFeeResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/scalex/fees',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ScalexRateFeeResponseDto _value;
+    try {
+      _value = ScalexRateFeeResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<ScalexBrijFeeResponseDto> fetchScalexBrijFees(
-      ScalexBrijFeeRequestDto request) async {
+    ScalexBrijFeeRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<ScalexBrijFeeResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/scalex/brij/fees',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = ScalexBrijFeeResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ScalexBrijFeeResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/scalex/brij/fees',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ScalexBrijFeeResponseDto _value;
+    try {
+      _value = ScalexBrijFeeResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -341,138 +348,137 @@ class _EspressoCashClient implements EspressoCashClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/updateUserWalletCountry',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/updateUserWalletCountry',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
   Future<PaymentQuoteResponseDto> getDlnQuote(
-      PaymentQuoteRequestDto request) async {
+    PaymentQuoteRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<PaymentQuoteResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/dln/quote',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = PaymentQuoteResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<PaymentQuoteResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/dln/quote',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late PaymentQuoteResponseDto _value;
+    try {
+      _value = PaymentQuoteResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<OrderIdDlnResponseDto> fetchDlnOrderId(
-      OrderIdDlnRequestDto request) async {
+    OrderIdDlnRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<OrderIdDlnResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/dln/orderId',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = OrderIdDlnResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<OrderIdDlnResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/dln/orderId',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late OrderIdDlnResponseDto _value;
+    try {
+      _value = OrderIdDlnResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<OrderStatusDlnResponseDto> fetchDlnStatus(
-      OrderStatusDlnRequestDto request) async {
+    OrderStatusDlnRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<OrderStatusDlnResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/dln/status',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = OrderStatusDlnResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<OrderStatusDlnResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/dln/status',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late OrderStatusDlnResponseDto _value;
+    try {
+      _value = OrderStatusDlnResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<IncomingQuoteResponseDto> getIncomingDlnQuote(
-      IncomingQuoteRequestDto request) async {
+    IncomingQuoteRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<IncomingQuoteResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/dln/incoming/quote',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = IncomingQuoteResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<IncomingQuoteResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/dln/incoming/quote',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late IncomingQuoteResponseDto _value;
+    try {
+      _value = IncomingQuoteResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -481,54 +487,55 @@ class _EspressoCashClient implements EspressoCashClient {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<GetFreeNonceResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/getFreeNonce',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = GetFreeNonceResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<GetFreeNonceResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/getFreeNonce',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late GetFreeNonceResponseDto _value;
+    try {
+      _value = GetFreeNonceResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<SubmitDurableTxResponseDto> submitDurableTx(
-      SubmitDurableTxRequestDto request) async {
+    SubmitDurableTxRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<SubmitDurableTxResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/submitDurableTx',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = SubmitDurableTxResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<SubmitDurableTxResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/submitDurableTx',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late SubmitDurableTxResponseDto _value;
+    try {
+      _value = SubmitDurableTxResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -537,83 +544,85 @@ class _EspressoCashClient implements EspressoCashClient {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<GetDurableFeesResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/getDurableFees',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = GetDurableFeesResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<GetDurableFeesResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/getDurableFees',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late GetDurableFeesResponseDto _value;
+    try {
+      _value = GetDurableFeesResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<ShortenLinkResponseDto> shortenLink(
-      ShortenLinkRequestDto request) async {
+    ShortenLinkRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<ShortenLinkResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/shortenLink',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = ShortenLinkResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ShortenLinkResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/shortenLink',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ShortenLinkResponseDto _value;
+    try {
+      _value = ShortenLinkResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<UnshortenLinkResponseDto> unshortenLink(
-      UnshortenLinkRequestDto request) async {
+    UnshortenLinkRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<UnshortenLinkResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/unshortenLink',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = UnshortenLinkResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<UnshortenLinkResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/unshortenLink',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late UnshortenLinkResponseDto _value;
+    try {
+      _value = UnshortenLinkResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -623,25 +632,25 @@ class _EspressoCashClient implements EspressoCashClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio
-        .fetch<Map<String, dynamic>>(_setStreamType<GasFeeResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/dln/incoming/gasFee',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = GasFeeResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<GasFeeResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/dln/incoming/gasFee',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late GasFeeResponseDto _value;
+    try {
+      _value = GasFeeResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -650,25 +659,25 @@ class _EspressoCashClient implements EspressoCashClient {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<GetRatesResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/rates',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = GetRatesResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<GetRatesResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/rates',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late GetRatesResponseDto _value;
+    try {
+      _value = GetRatesResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -678,170 +687,175 @@ class _EspressoCashClient implements EspressoCashClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<FiatRateResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/fiatRate',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = FiatRateResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<FiatRateResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/fiatRate',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late FiatRateResponseDto _value;
+    try {
+      _value = FiatRateResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<PriorityFeesResponseDto> getPriorityFeeEstimate(
-      PriorityFeesRequestDto request) async {
+    PriorityFeesRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<PriorityFeesResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/getPriorityFeeEstimate',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = PriorityFeesResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<PriorityFeesResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/getPriorityFeeEstimate',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late PriorityFeesResponseDto _value;
+    try {
+      _value = PriorityFeesResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<MoneygramChallengeSignResponseDto> signChallenge(
-      MoneygramChallengeSignRequestDto request) async {
+    MoneygramChallengeSignRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<MoneygramChallengeSignResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/moneygram/sign',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = MoneygramChallengeSignResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<MoneygramChallengeSignResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/moneygram/sign',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late MoneygramChallengeSignResponseDto _value;
+    try {
+      _value = MoneygramChallengeSignResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<MoneygramSwapResponseDto> swapToSolana(
-      SwapToSolanaRequestDto request) async {
+    SwapToSolanaRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<MoneygramSwapResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/moneygram/swapToSolana',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = MoneygramSwapResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<MoneygramSwapResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/moneygram/swapToSolana',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late MoneygramSwapResponseDto _value;
+    try {
+      _value = MoneygramSwapResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<MoneygramSwapResponseDto> swapToStellar(
-      SwapToStellarRequestDto request) async {
+    SwapToStellarRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<MoneygramSwapResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/moneygram/swapToStellar',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = MoneygramSwapResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<MoneygramSwapResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/moneygram/swapToStellar',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late MoneygramSwapResponseDto _value;
+    try {
+      _value = MoneygramSwapResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<MoneygramFeeResponseDto> calculateMoneygramFee(
-      MoneygramFeeRequestDto request) async {
+    MoneygramFeeRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<MoneygramFeeResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/moneygram/calculateFee',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = MoneygramFeeResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<MoneygramFeeResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/moneygram/calculateFee',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late MoneygramFeeResponseDto _value;
+    try {
+      _value = MoneygramFeeResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -851,22 +865,17 @@ class _EspressoCashClient implements EspressoCashClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/moneygram/fund',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/moneygram/fund',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -875,51 +884,47 @@ class _EspressoCashClient implements EspressoCashClient {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<GetTokensMetaResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/tokens/meta',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = GetTokensMetaResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<GetTokensMetaResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/tokens/meta',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late GetTokensMetaResponseDto _value;
+    try {
+      _value = GetTokensMetaResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
   Future<void> addAmbassadorReferral(
-      AmbassadorReferralRequestDto request) async {
+    AmbassadorReferralRequestDto request,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(request.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/ambassador/addReferral',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/ambassador/addReferral',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -928,25 +933,25 @@ class _EspressoCashClient implements EspressoCashClient {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<AmbassadorStatsResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/ambassador/stats',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = AmbassadorStatsResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<AmbassadorStatsResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/ambassador/stats',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late AmbassadorStatsResponseDto _value;
+    try {
+      _value = AmbassadorStatsResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -955,25 +960,25 @@ class _EspressoCashClient implements EspressoCashClient {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<AmbassadorVerificationResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              '/ambassador/verify',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
-    final value = AmbassadorVerificationResponseDto.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<AmbassadorVerificationResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/ambassador/verify',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late AmbassadorVerificationResponseDto _value;
+    try {
+      _value = AmbassadorVerificationResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
@@ -989,10 +994,7 @@ class _EspressoCashClient implements EspressoCashClient {
     return requestOptions;
   }
 
-  String _combineBaseUrls(
-    String dioBaseUrl,
-    String? baseUrl,
-  ) {
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
     if (baseUrl == null || baseUrl.trim().isEmpty) {
       return dioBaseUrl;
     }

--- a/packages/espressocash_api/lib/src/dto/dln_payment.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/dln_payment.freezed.dart
@@ -25,8 +25,12 @@ mixin _$PaymentQuoteRequestDto {
   String get receiverAddress => throw _privateConstructorUsedError;
   String get receiverBlockchain => throw _privateConstructorUsedError;
 
+  /// Serializes this PaymentQuoteRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PaymentQuoteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PaymentQuoteRequestDtoCopyWith<PaymentQuoteRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -51,6 +55,8 @@ class _$PaymentQuoteRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PaymentQuoteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -97,6 +103,8 @@ class __$$PaymentQuoteRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$PaymentQuoteRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PaymentQuoteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -156,12 +164,14 @@ class _$PaymentQuoteRequestDtoImpl implements _PaymentQuoteRequestDto {
                 other.receiverBlockchain == receiverBlockchain));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, amount, receiverAddress, receiverBlockchain);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PaymentQuoteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PaymentQuoteRequestDtoImplCopyWith<_$PaymentQuoteRequestDtoImpl>
@@ -191,8 +201,11 @@ abstract class _PaymentQuoteRequestDto implements PaymentQuoteRequestDto {
   String get receiverAddress;
   @override
   String get receiverBlockchain;
+
+  /// Create a copy of PaymentQuoteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PaymentQuoteRequestDtoImplCopyWith<_$PaymentQuoteRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -210,8 +223,12 @@ mixin _$PaymentQuoteResponseDto {
   int get feeInUsdc => throw _privateConstructorUsedError;
   BigInt get slot => throw _privateConstructorUsedError;
 
+  /// Serializes this PaymentQuoteResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PaymentQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PaymentQuoteResponseDtoCopyWith<PaymentQuoteResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -241,6 +258,8 @@ class _$PaymentQuoteResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PaymentQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -302,6 +321,8 @@ class __$$PaymentQuoteResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$PaymentQuoteResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PaymentQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -381,12 +402,14 @@ class _$PaymentQuoteResponseDtoImpl implements _PaymentQuoteResponseDto {
             (identical(other.slot, slot) || other.slot == slot));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, inputAmount, receiverAmount, encodedTx, feeInUsdc, slot);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PaymentQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PaymentQuoteResponseDtoImplCopyWith<_$PaymentQuoteResponseDtoImpl>
@@ -422,8 +445,11 @@ abstract class _PaymentQuoteResponseDto implements PaymentQuoteResponseDto {
   int get feeInUsdc;
   @override
   BigInt get slot;
+
+  /// Create a copy of PaymentQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PaymentQuoteResponseDtoImplCopyWith<_$PaymentQuoteResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -437,8 +463,12 @@ OrderStatusDlnRequestDto _$OrderStatusDlnRequestDtoFromJson(
 mixin _$OrderStatusDlnRequestDto {
   String get orderId => throw _privateConstructorUsedError;
 
+  /// Serializes this OrderStatusDlnRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OrderStatusDlnRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OrderStatusDlnRequestDtoCopyWith<OrderStatusDlnRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -463,6 +493,8 @@ class _$OrderStatusDlnRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OrderStatusDlnRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -499,6 +531,8 @@ class __$$OrderStatusDlnRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$OrderStatusDlnRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OrderStatusDlnRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -537,11 +571,13 @@ class _$OrderStatusDlnRequestDtoImpl implements _OrderStatusDlnRequestDto {
             (identical(other.orderId, orderId) || other.orderId == orderId));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, orderId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OrderStatusDlnRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OrderStatusDlnRequestDtoImplCopyWith<_$OrderStatusDlnRequestDtoImpl>
@@ -565,8 +601,11 @@ abstract class _OrderStatusDlnRequestDto implements OrderStatusDlnRequestDto {
 
   @override
   String get orderId;
+
+  /// Create a copy of OrderStatusDlnRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OrderStatusDlnRequestDtoImplCopyWith<_$OrderStatusDlnRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -580,8 +619,12 @@ OrderStatusDlnResponseDto _$OrderStatusDlnResponseDtoFromJson(
 mixin _$OrderStatusDlnResponseDto {
   DlnOrderStatus get status => throw _privateConstructorUsedError;
 
+  /// Serializes this OrderStatusDlnResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OrderStatusDlnResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OrderStatusDlnResponseDtoCopyWith<OrderStatusDlnResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -606,6 +649,8 @@ class _$OrderStatusDlnResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OrderStatusDlnResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -642,6 +687,8 @@ class __$$OrderStatusDlnResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$OrderStatusDlnResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OrderStatusDlnResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -680,11 +727,13 @@ class _$OrderStatusDlnResponseDtoImpl implements _OrderStatusDlnResponseDto {
             (identical(other.status, status) || other.status == status));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, status);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OrderStatusDlnResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OrderStatusDlnResponseDtoImplCopyWith<_$OrderStatusDlnResponseDtoImpl>
@@ -708,8 +757,11 @@ abstract class _OrderStatusDlnResponseDto implements OrderStatusDlnResponseDto {
 
   @override
   DlnOrderStatus get status;
+
+  /// Create a copy of OrderStatusDlnResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OrderStatusDlnResponseDtoImplCopyWith<_$OrderStatusDlnResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -722,8 +774,12 @@ OrderIdDlnRequestDto _$OrderIdDlnRequestDtoFromJson(Map<String, dynamic> json) {
 mixin _$OrderIdDlnRequestDto {
   String get txId => throw _privateConstructorUsedError;
 
+  /// Serializes this OrderIdDlnRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OrderIdDlnRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OrderIdDlnRequestDtoCopyWith<OrderIdDlnRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -748,6 +804,8 @@ class _$OrderIdDlnRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OrderIdDlnRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -781,6 +839,8 @@ class __$$OrderIdDlnRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$OrderIdDlnRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OrderIdDlnRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -819,11 +879,13 @@ class _$OrderIdDlnRequestDtoImpl implements _OrderIdDlnRequestDto {
             (identical(other.txId, txId) || other.txId == txId));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, txId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OrderIdDlnRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OrderIdDlnRequestDtoImplCopyWith<_$OrderIdDlnRequestDtoImpl>
@@ -848,8 +910,11 @@ abstract class _OrderIdDlnRequestDto implements OrderIdDlnRequestDto {
 
   @override
   String get txId;
+
+  /// Create a copy of OrderIdDlnRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OrderIdDlnRequestDtoImplCopyWith<_$OrderIdDlnRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -863,8 +928,12 @@ OrderIdDlnResponseDto _$OrderIdDlnResponseDtoFromJson(
 mixin _$OrderIdDlnResponseDto {
   String? get orderId => throw _privateConstructorUsedError;
 
+  /// Serializes this OrderIdDlnResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OrderIdDlnResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OrderIdDlnResponseDtoCopyWith<OrderIdDlnResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -889,6 +958,8 @@ class _$OrderIdDlnResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OrderIdDlnResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -924,6 +995,8 @@ class __$$OrderIdDlnResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$OrderIdDlnResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OrderIdDlnResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -962,11 +1035,13 @@ class _$OrderIdDlnResponseDtoImpl implements _OrderIdDlnResponseDto {
             (identical(other.orderId, orderId) || other.orderId == orderId));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, orderId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OrderIdDlnResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OrderIdDlnResponseDtoImplCopyWith<_$OrderIdDlnResponseDtoImpl>
@@ -990,8 +1065,11 @@ abstract class _OrderIdDlnResponseDto implements OrderIdDlnResponseDto {
 
   @override
   String? get orderId;
+
+  /// Create a copy of OrderIdDlnResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OrderIdDlnResponseDtoImplCopyWith<_$OrderIdDlnResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1009,8 +1087,12 @@ mixin _$IncomingQuoteRequestDto {
   String get receiverAddress => throw _privateConstructorUsedError;
   String? get solanaReferenceAddress => throw _privateConstructorUsedError;
 
+  /// Serializes this IncomingQuoteRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of IncomingQuoteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $IncomingQuoteRequestDtoCopyWith<IncomingQuoteRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1040,6 +1122,8 @@ class _$IncomingQuoteRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of IncomingQuoteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1101,6 +1185,8 @@ class __$$IncomingQuoteRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$IncomingQuoteRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of IncomingQuoteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1180,12 +1266,14 @@ class _$IncomingQuoteRequestDtoImpl implements _IncomingQuoteRequestDto {
                 other.solanaReferenceAddress == solanaReferenceAddress));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, amount, senderAddress,
       senderBlockchain, receiverAddress, solanaReferenceAddress);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of IncomingQuoteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$IncomingQuoteRequestDtoImplCopyWith<_$IncomingQuoteRequestDtoImpl>
@@ -1222,8 +1310,11 @@ abstract class _IncomingQuoteRequestDto implements IncomingQuoteRequestDto {
   String get receiverAddress;
   @override
   String? get solanaReferenceAddress;
+
+  /// Create a copy of IncomingQuoteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$IncomingQuoteRequestDtoImplCopyWith<_$IncomingQuoteRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1241,8 +1332,12 @@ mixin _$IncomingQuoteResponseDto {
   int get receiverAmount => throw _privateConstructorUsedError;
   int get feeInUsdc => throw _privateConstructorUsedError;
 
+  /// Serializes this IncomingQuoteResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of IncomingQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $IncomingQuoteResponseDtoCopyWith<IncomingQuoteResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1275,6 +1370,8 @@ class _$IncomingQuoteResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of IncomingQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1308,6 +1405,8 @@ class _$IncomingQuoteResponseDtoCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of IncomingQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $QuoteTxCopyWith<$Res> get tx {
@@ -1316,6 +1415,8 @@ class _$IncomingQuoteResponseDtoCopyWithImpl<$Res,
     });
   }
 
+  /// Create a copy of IncomingQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $QuoteUsdcInfoCopyWith<$Res> get usdcInfo {
@@ -1357,6 +1458,8 @@ class __$$IncomingQuoteResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$IncomingQuoteResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of IncomingQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1436,12 +1539,14 @@ class _$IncomingQuoteResponseDtoImpl implements _IncomingQuoteResponseDto {
                 other.feeInUsdc == feeInUsdc));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, tx, usdcInfo, inputAmount, receiverAmount, feeInUsdc);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of IncomingQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$IncomingQuoteResponseDtoImplCopyWith<_$IncomingQuoteResponseDtoImpl>
@@ -1477,8 +1582,11 @@ abstract class _IncomingQuoteResponseDto implements IncomingQuoteResponseDto {
   int get receiverAmount;
   @override
   int get feeInUsdc;
+
+  /// Create a copy of IncomingQuoteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$IncomingQuoteResponseDtoImplCopyWith<_$IncomingQuoteResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1493,8 +1601,12 @@ mixin _$QuoteTx {
   String get data => throw _privateConstructorUsedError;
   int get value => throw _privateConstructorUsedError;
 
+  /// Serializes this QuoteTx to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of QuoteTx
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $QuoteTxCopyWith<QuoteTx> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -1516,6 +1628,8 @@ class _$QuoteTxCopyWithImpl<$Res, $Val extends QuoteTx>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of QuoteTx
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1558,6 +1672,8 @@ class __$$QuoteTxImplCopyWithImpl<$Res>
       _$QuoteTxImpl _value, $Res Function(_$QuoteTxImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of QuoteTx
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1613,11 +1729,13 @@ class _$QuoteTxImpl implements _QuoteTx {
             (identical(other.value, value) || other.value == value));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, to, data, value);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of QuoteTx
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$QuoteTxImplCopyWith<_$QuoteTxImpl> get copyWith =>
@@ -1645,8 +1763,11 @@ abstract class _QuoteTx implements QuoteTx {
   String get data;
   @override
   int get value;
+
+  /// Create a copy of QuoteTx
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$QuoteTxImplCopyWith<_$QuoteTxImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1660,8 +1781,12 @@ mixin _$QuoteUsdcInfo {
   String get usdcAddress => throw _privateConstructorUsedError;
   int get approvalAmount => throw _privateConstructorUsedError;
 
+  /// Serializes this QuoteUsdcInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of QuoteUsdcInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $QuoteUsdcInfoCopyWith<QuoteUsdcInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1685,6 +1810,8 @@ class _$QuoteUsdcInfoCopyWithImpl<$Res, $Val extends QuoteUsdcInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of QuoteUsdcInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1723,6 +1850,8 @@ class __$$QuoteUsdcInfoImplCopyWithImpl<$Res>
       _$QuoteUsdcInfoImpl _value, $Res Function(_$QuoteUsdcInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of QuoteUsdcInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1772,11 +1901,13 @@ class _$QuoteUsdcInfoImpl implements _QuoteUsdcInfo {
                 other.approvalAmount == approvalAmount));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, usdcAddress, approvalAmount);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of QuoteUsdcInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$QuoteUsdcInfoImplCopyWith<_$QuoteUsdcInfoImpl> get copyWith =>
@@ -1802,8 +1933,11 @@ abstract class _QuoteUsdcInfo implements QuoteUsdcInfo {
   String get usdcAddress;
   @override
   int get approvalAmount;
+
+  /// Create a copy of QuoteUsdcInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$QuoteUsdcInfoImplCopyWith<_$QuoteUsdcInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/durable_transactions.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/durable_transactions.freezed.dart
@@ -25,8 +25,12 @@ mixin _$GetFreeNonceResponseDto {
   String get nonceAccount => throw _privateConstructorUsedError;
   String get authority => throw _privateConstructorUsedError;
 
+  /// Serializes this GetFreeNonceResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GetFreeNonceResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GetFreeNonceResponseDtoCopyWith<GetFreeNonceResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -51,6 +55,8 @@ class _$GetFreeNonceResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GetFreeNonceResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -97,6 +103,8 @@ class __$$GetFreeNonceResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$GetFreeNonceResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GetFreeNonceResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -156,11 +164,13 @@ class _$GetFreeNonceResponseDtoImpl implements _GetFreeNonceResponseDto {
                 other.authority == authority));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, nonce, nonceAccount, authority);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GetFreeNonceResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GetFreeNonceResponseDtoImplCopyWith<_$GetFreeNonceResponseDtoImpl>
@@ -190,8 +200,11 @@ abstract class _GetFreeNonceResponseDto implements GetFreeNonceResponseDto {
   String get nonceAccount;
   @override
   String get authority;
+
+  /// Create a copy of GetFreeNonceResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GetFreeNonceResponseDtoImplCopyWith<_$GetFreeNonceResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -205,8 +218,12 @@ SubmitDurableTxRequestDto _$SubmitDurableTxRequestDtoFromJson(
 mixin _$SubmitDurableTxRequestDto {
   String get tx => throw _privateConstructorUsedError;
 
+  /// Serializes this SubmitDurableTxRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SubmitDurableTxRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SubmitDurableTxRequestDtoCopyWith<SubmitDurableTxRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -231,6 +248,8 @@ class _$SubmitDurableTxRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SubmitDurableTxRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -267,6 +286,8 @@ class __$$SubmitDurableTxRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$SubmitDurableTxRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SubmitDurableTxRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -305,11 +326,13 @@ class _$SubmitDurableTxRequestDtoImpl implements _SubmitDurableTxRequestDto {
             (identical(other.tx, tx) || other.tx == tx));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, tx);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SubmitDurableTxRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SubmitDurableTxRequestDtoImplCopyWith<_$SubmitDurableTxRequestDtoImpl>
@@ -333,8 +356,11 @@ abstract class _SubmitDurableTxRequestDto implements SubmitDurableTxRequestDto {
 
   @override
   String get tx;
+
+  /// Create a copy of SubmitDurableTxRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SubmitDurableTxRequestDtoImplCopyWith<_$SubmitDurableTxRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -348,8 +374,12 @@ SubmitDurableTxResponseDto _$SubmitDurableTxResponseDtoFromJson(
 mixin _$SubmitDurableTxResponseDto {
   String get signature => throw _privateConstructorUsedError;
 
+  /// Serializes this SubmitDurableTxResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SubmitDurableTxResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SubmitDurableTxResponseDtoCopyWith<SubmitDurableTxResponseDto>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -375,6 +405,8 @@ class _$SubmitDurableTxResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SubmitDurableTxResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -411,6 +443,8 @@ class __$$SubmitDurableTxResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$SubmitDurableTxResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SubmitDurableTxResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -451,11 +485,13 @@ class _$SubmitDurableTxResponseDtoImpl implements _SubmitDurableTxResponseDto {
                 other.signature == signature));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, signature);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SubmitDurableTxResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SubmitDurableTxResponseDtoImplCopyWith<_$SubmitDurableTxResponseDtoImpl>
@@ -480,8 +516,11 @@ abstract class _SubmitDurableTxResponseDto
 
   @override
   String get signature;
+
+  /// Create a copy of SubmitDurableTxResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SubmitDurableTxResponseDtoImplCopyWith<_$SubmitDurableTxResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -497,8 +536,12 @@ mixin _$GetDurableFeesResponseDto {
   int get incomingLink => throw _privateConstructorUsedError;
   int get cancelLink => throw _privateConstructorUsedError;
 
+  /// Serializes this GetDurableFeesResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GetDurableFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GetDurableFeesResponseDtoCopyWith<GetDurableFeesResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -523,6 +566,8 @@ class _$GetDurableFeesResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GetDurableFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -569,6 +614,8 @@ class __$$GetDurableFeesResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$GetDurableFeesResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GetDurableFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -629,12 +676,14 @@ class _$GetDurableFeesResponseDtoImpl implements _GetDurableFeesResponseDto {
                 other.cancelLink == cancelLink));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, outgoingLink, incomingLink, cancelLink);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GetDurableFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GetDurableFeesResponseDtoImplCopyWith<_$GetDurableFeesResponseDtoImpl>
@@ -664,8 +713,11 @@ abstract class _GetDurableFeesResponseDto implements GetDurableFeesResponseDto {
   int get incomingLink;
   @override
   int get cancelLink;
+
+  /// Create a copy of GetDurableFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GetDurableFeesResponseDtoImplCopyWith<_$GetDurableFeesResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/gas.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/gas.freezed.dart
@@ -22,8 +22,12 @@ GasFeeRequestDto _$GasFeeRequestDtoFromJson(Map<String, dynamic> json) {
 mixin _$GasFeeRequestDto {
   String get network => throw _privateConstructorUsedError;
 
+  /// Serializes this GasFeeRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GasFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GasFeeRequestDtoCopyWith<GasFeeRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -47,6 +51,8 @@ class _$GasFeeRequestDtoCopyWithImpl<$Res, $Val extends GasFeeRequestDto>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GasFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -80,6 +86,8 @@ class __$$GasFeeRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$GasFeeRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GasFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -118,11 +126,13 @@ class _$GasFeeRequestDtoImpl implements _GasFeeRequestDto {
             (identical(other.network, network) || other.network == network));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, network);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GasFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GasFeeRequestDtoImplCopyWith<_$GasFeeRequestDtoImpl> get copyWith =>
@@ -146,8 +156,11 @@ abstract class _GasFeeRequestDto implements GasFeeRequestDto {
 
   @override
   String get network;
+
+  /// Create a copy of GasFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GasFeeRequestDtoImplCopyWith<_$GasFeeRequestDtoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -164,8 +177,12 @@ mixin _$GasFeeResponseDto {
   String get estimatedBaseFee => throw _privateConstructorUsedError;
   double get networkCongestion => throw _privateConstructorUsedError;
 
+  /// Serializes this GasFeeResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GasFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GasFeeResponseDtoCopyWith<GasFeeResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -198,6 +215,8 @@ class _$GasFeeResponseDtoCopyWithImpl<$Res, $Val extends GasFeeResponseDto>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GasFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -231,6 +250,8 @@ class _$GasFeeResponseDtoCopyWithImpl<$Res, $Val extends GasFeeResponseDto>
     ) as $Val);
   }
 
+  /// Create a copy of GasFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GasFeeEstimateCopyWith<$Res> get low {
@@ -239,6 +260,8 @@ class _$GasFeeResponseDtoCopyWithImpl<$Res, $Val extends GasFeeResponseDto>
     });
   }
 
+  /// Create a copy of GasFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GasFeeEstimateCopyWith<$Res> get medium {
@@ -247,6 +270,8 @@ class _$GasFeeResponseDtoCopyWithImpl<$Res, $Val extends GasFeeResponseDto>
     });
   }
 
+  /// Create a copy of GasFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GasFeeEstimateCopyWith<$Res> get high {
@@ -287,6 +312,8 @@ class __$$GasFeeResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$GasFeeResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GasFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -364,12 +391,14 @@ class _$GasFeeResponseDtoImpl implements _GasFeeResponseDto {
                 other.networkCongestion == networkCongestion));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, low, medium, high, estimatedBaseFee, networkCongestion);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GasFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GasFeeResponseDtoImplCopyWith<_$GasFeeResponseDtoImpl> get copyWith =>
@@ -405,8 +434,11 @@ abstract class _GasFeeResponseDto implements GasFeeResponseDto {
   String get estimatedBaseFee;
   @override
   double get networkCongestion;
+
+  /// Create a copy of GasFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GasFeeResponseDtoImplCopyWith<_$GasFeeResponseDtoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -423,8 +455,12 @@ mixin _$GasFeeEstimate {
   int get minWaitTimeEstimate => throw _privateConstructorUsedError;
   int get maxWaitTimeEstimate => throw _privateConstructorUsedError;
 
+  /// Serializes this GasFeeEstimate to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GasFeeEstimate
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GasFeeEstimateCopyWith<GasFeeEstimate> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -452,6 +488,8 @@ class _$GasFeeEstimateCopyWithImpl<$Res, $Val extends GasFeeEstimate>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GasFeeEstimate
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -504,6 +542,8 @@ class __$$GasFeeEstimateImplCopyWithImpl<$Res>
       _$GasFeeEstimateImpl _value, $Res Function(_$GasFeeEstimateImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GasFeeEstimate
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -576,12 +616,14 @@ class _$GasFeeEstimateImpl implements _GasFeeEstimate {
                 other.maxWaitTimeEstimate == maxWaitTimeEstimate));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, suggestedMaxPriorityFeePerGas,
       suggestedMaxFeePerGas, minWaitTimeEstimate, maxWaitTimeEstimate);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GasFeeEstimate
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GasFeeEstimateImplCopyWith<_$GasFeeEstimateImpl> get copyWith =>
@@ -614,8 +656,11 @@ abstract class _GasFeeEstimate implements GasFeeEstimate {
   int get minWaitTimeEstimate;
   @override
   int get maxWaitTimeEstimate;
+
+  /// Create a copy of GasFeeEstimate
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GasFeeEstimateImplCopyWith<_$GasFeeEstimateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/get_fees.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/get_fees.freezed.dart
@@ -27,8 +27,12 @@ mixin _$GetFeesResponseDto {
   WithdrawFeeDto get withdrawFeePercentage =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this GetFeesResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GetFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GetFeesResponseDtoCopyWith<GetFeesResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -60,6 +64,8 @@ class _$GetFeesResponseDtoCopyWithImpl<$Res, $Val extends GetFeesResponseDto>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GetFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -93,6 +99,8 @@ class _$GetFeesResponseDtoCopyWithImpl<$Res, $Val extends GetFeesResponseDto>
     ) as $Val);
   }
 
+  /// Create a copy of GetFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $DirectPaymentFeeDtoCopyWith<$Res> get directPayment {
@@ -101,6 +109,8 @@ class _$GetFeesResponseDtoCopyWithImpl<$Res, $Val extends GetFeesResponseDto>
     });
   }
 
+  /// Create a copy of GetFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $WithdrawFeeDtoCopyWith<$Res> get withdrawFeePercentage {
@@ -139,6 +149,8 @@ class __$$GetFeesResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$GetFeesResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GetFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -220,12 +232,14 @@ class _$GetFeesResponseDtoImpl implements _GetFeesResponseDto {
                 other.withdrawFeePercentage == withdrawFeePercentage));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, directPayment, escrowPayment,
       escrowPaymentAtaFee, splitKeyPayment, withdrawFeePercentage);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GetFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GetFeesResponseDtoImplCopyWith<_$GetFeesResponseDtoImpl> get copyWith =>
@@ -261,8 +275,11 @@ abstract class _GetFeesResponseDto implements GetFeesResponseDto {
   int get splitKeyPayment;
   @override
   WithdrawFeeDto get withdrawFeePercentage;
+
+  /// Create a copy of GetFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GetFeesResponseDtoImplCopyWith<_$GetFeesResponseDtoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -276,8 +293,12 @@ mixin _$DirectPaymentFeeDto {
   int get ataExists => throw _privateConstructorUsedError;
   int get ataDoesNotExist => throw _privateConstructorUsedError;
 
+  /// Serializes this DirectPaymentFeeDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of DirectPaymentFeeDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DirectPaymentFeeDtoCopyWith<DirectPaymentFeeDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -301,6 +322,8 @@ class _$DirectPaymentFeeDtoCopyWithImpl<$Res, $Val extends DirectPaymentFeeDto>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of DirectPaymentFeeDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -339,6 +362,8 @@ class __$$DirectPaymentFeeDtoImplCopyWithImpl<$Res>
       $Res Function(_$DirectPaymentFeeDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of DirectPaymentFeeDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -388,11 +413,13 @@ class _$DirectPaymentFeeDtoImpl implements _DirectPaymentFeeDto {
                 other.ataDoesNotExist == ataDoesNotExist));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, ataExists, ataDoesNotExist);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of DirectPaymentFeeDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DirectPaymentFeeDtoImplCopyWith<_$DirectPaymentFeeDtoImpl> get copyWith =>
@@ -419,8 +446,11 @@ abstract class _DirectPaymentFeeDto implements DirectPaymentFeeDto {
   int get ataExists;
   @override
   int get ataDoesNotExist;
+
+  /// Create a copy of DirectPaymentFeeDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DirectPaymentFeeDtoImplCopyWith<_$DirectPaymentFeeDtoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -437,8 +467,12 @@ mixin _$WithdrawFeeDto {
   double get coinflow => throw _privateConstructorUsedError;
   double get guardarian => throw _privateConstructorUsedError;
 
+  /// Serializes this WithdrawFeeDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of WithdrawFeeDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $WithdrawFeeDtoCopyWith<WithdrawFeeDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -467,6 +501,8 @@ class _$WithdrawFeeDtoCopyWithImpl<$Res, $Val extends WithdrawFeeDto>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of WithdrawFeeDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -525,6 +561,8 @@ class __$$WithdrawFeeDtoImplCopyWithImpl<$Res>
       _$WithdrawFeeDtoImpl _value, $Res Function(_$WithdrawFeeDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of WithdrawFeeDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -608,12 +646,14 @@ class _$WithdrawFeeDtoImpl implements _WithdrawFeeDto {
                 other.guardarian == guardarian));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, scalex, kado, rampNetwork, coinflow, guardarian);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of WithdrawFeeDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$WithdrawFeeDtoImplCopyWith<_$WithdrawFeeDtoImpl> get copyWith =>
@@ -649,8 +689,11 @@ abstract class _WithdrawFeeDto implements WithdrawFeeDto {
   double get coinflow;
   @override
   double get guardarian;
+
+  /// Create a copy of WithdrawFeeDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$WithdrawFeeDtoImplCopyWith<_$WithdrawFeeDtoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/get_rates.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/get_rates.freezed.dart
@@ -22,8 +22,12 @@ GetRatesResponseDto _$GetRatesResponseDtoFromJson(Map<String, dynamic> json) {
 mixin _$GetRatesResponseDto {
   double get usdc => throw _privateConstructorUsedError;
 
+  /// Serializes this GetRatesResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GetRatesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GetRatesResponseDtoCopyWith<GetRatesResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -47,6 +51,8 @@ class _$GetRatesResponseDtoCopyWithImpl<$Res, $Val extends GetRatesResponseDto>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GetRatesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -80,6 +86,8 @@ class __$$GetRatesResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$GetRatesResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GetRatesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -118,11 +126,13 @@ class _$GetRatesResponseDtoImpl implements _GetRatesResponseDto {
             (identical(other.usdc, usdc) || other.usdc == usdc));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, usdc);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GetRatesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GetRatesResponseDtoImplCopyWith<_$GetRatesResponseDtoImpl> get copyWith =>
@@ -146,8 +156,11 @@ abstract class _GetRatesResponseDto implements GetRatesResponseDto {
 
   @override
   double get usdc;
+
+  /// Create a copy of GetRatesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GetRatesResponseDtoImplCopyWith<_$GetRatesResponseDtoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/get_tokens.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/get_tokens.freezed.dart
@@ -23,8 +23,12 @@ GetTokensMetaResponseDto _$GetTokensMetaResponseDtoFromJson(
 mixin _$GetTokensMetaResponseDto {
   String get md5 => throw _privateConstructorUsedError;
 
+  /// Serializes this GetTokensMetaResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GetTokensMetaResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GetTokensMetaResponseDtoCopyWith<GetTokensMetaResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -49,6 +53,8 @@ class _$GetTokensMetaResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GetTokensMetaResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -85,6 +91,8 @@ class __$$GetTokensMetaResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$GetTokensMetaResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GetTokensMetaResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -123,11 +131,13 @@ class _$GetTokensMetaResponseDtoImpl implements _GetTokensMetaResponseDto {
             (identical(other.md5, md5) || other.md5 == md5));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, md5);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GetTokensMetaResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GetTokensMetaResponseDtoImplCopyWith<_$GetTokensMetaResponseDtoImpl>
@@ -151,8 +161,11 @@ abstract class _GetTokensMetaResponseDto implements GetTokensMetaResponseDto {
 
   @override
   String get md5;
+
+  /// Create a copy of GetTokensMetaResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GetTokensMetaResponseDtoImplCopyWith<_$GetTokensMetaResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/moneygram.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/moneygram.freezed.dart
@@ -23,8 +23,12 @@ MoneygramChallengeSignRequestDto _$MoneygramChallengeSignRequestDtoFromJson(
 mixin _$MoneygramChallengeSignRequestDto {
   String get signedTx => throw _privateConstructorUsedError;
 
+  /// Serializes this MoneygramChallengeSignRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MoneygramChallengeSignRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MoneygramChallengeSignRequestDtoCopyWith<MoneygramChallengeSignRequestDto>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -51,6 +55,8 @@ class _$MoneygramChallengeSignRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MoneygramChallengeSignRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -87,6 +93,8 @@ class __$$MoneygramChallengeSignRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$MoneygramChallengeSignRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MoneygramChallengeSignRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -128,11 +136,13 @@ class _$MoneygramChallengeSignRequestDtoImpl
                 other.signedTx == signedTx));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, signedTx);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MoneygramChallengeSignRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MoneygramChallengeSignRequestDtoImplCopyWith<
@@ -160,8 +170,11 @@ abstract class _MoneygramChallengeSignRequestDto
 
   @override
   String get signedTx;
+
+  /// Create a copy of MoneygramChallengeSignRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MoneygramChallengeSignRequestDtoImplCopyWith<
           _$MoneygramChallengeSignRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -176,8 +189,12 @@ MoneygramChallengeSignResponseDto _$MoneygramChallengeSignResponseDtoFromJson(
 mixin _$MoneygramChallengeSignResponseDto {
   String get signedTx => throw _privateConstructorUsedError;
 
+  /// Serializes this MoneygramChallengeSignResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MoneygramChallengeSignResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MoneygramChallengeSignResponseDtoCopyWith<MoneygramChallengeSignResponseDto>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -204,6 +221,8 @@ class _$MoneygramChallengeSignResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MoneygramChallengeSignResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -240,6 +259,8 @@ class __$$MoneygramChallengeSignResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$MoneygramChallengeSignResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MoneygramChallengeSignResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -281,11 +302,13 @@ class _$MoneygramChallengeSignResponseDtoImpl
                 other.signedTx == signedTx));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, signedTx);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MoneygramChallengeSignResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MoneygramChallengeSignResponseDtoImplCopyWith<
@@ -313,8 +336,11 @@ abstract class _MoneygramChallengeSignResponseDto
 
   @override
   String get signedTx;
+
+  /// Create a copy of MoneygramChallengeSignResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MoneygramChallengeSignResponseDtoImplCopyWith<
           _$MoneygramChallengeSignResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -332,8 +358,12 @@ mixin _$SwapToStellarRequestDto {
   String get amount => throw _privateConstructorUsedError;
   int? get priorityFee => throw _privateConstructorUsedError;
 
+  /// Serializes this SwapToStellarRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SwapToStellarRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SwapToStellarRequestDtoCopyWith<SwapToStellarRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -362,6 +392,8 @@ class _$SwapToStellarRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SwapToStellarRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -417,6 +449,8 @@ class __$$SwapToStellarRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$SwapToStellarRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SwapToStellarRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -486,12 +520,14 @@ class _$SwapToStellarRequestDtoImpl implements _SwapToStellarRequestDto {
                 other.priorityFee == priorityFee));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, solanaSenderAddress,
       stellarReceiverAddress, amount, priorityFee);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SwapToStellarRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SwapToStellarRequestDtoImplCopyWith<_$SwapToStellarRequestDtoImpl>
@@ -524,8 +560,11 @@ abstract class _SwapToStellarRequestDto implements SwapToStellarRequestDto {
   String get amount;
   @override
   int? get priorityFee;
+
+  /// Create a copy of SwapToStellarRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SwapToStellarRequestDtoImplCopyWith<_$SwapToStellarRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -541,8 +580,12 @@ mixin _$SwapToSolanaRequestDto {
   String get solanaReceiverAddress => throw _privateConstructorUsedError;
   String get amount => throw _privateConstructorUsedError;
 
+  /// Serializes this SwapToSolanaRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SwapToSolanaRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SwapToSolanaRequestDtoCopyWith<SwapToSolanaRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -570,6 +613,8 @@ class _$SwapToSolanaRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SwapToSolanaRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -619,6 +664,8 @@ class __$$SwapToSolanaRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$SwapToSolanaRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SwapToSolanaRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -678,12 +725,14 @@ class _$SwapToSolanaRequestDtoImpl implements _SwapToSolanaRequestDto {
             (identical(other.amount, amount) || other.amount == amount));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, stellarSenderAddress, solanaReceiverAddress, amount);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SwapToSolanaRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SwapToSolanaRequestDtoImplCopyWith<_$SwapToSolanaRequestDtoImpl>
@@ -713,8 +762,11 @@ abstract class _SwapToSolanaRequestDto implements SwapToSolanaRequestDto {
   String get solanaReceiverAddress;
   @override
   String get amount;
+
+  /// Create a copy of SwapToSolanaRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SwapToSolanaRequestDtoImplCopyWith<_$SwapToSolanaRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -728,8 +780,12 @@ MoneygramSwapResponseDto _$MoneygramSwapResponseDtoFromJson(
 mixin _$MoneygramSwapResponseDto {
   String get encodedTx => throw _privateConstructorUsedError;
 
+  /// Serializes this MoneygramSwapResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MoneygramSwapResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MoneygramSwapResponseDtoCopyWith<MoneygramSwapResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -754,6 +810,8 @@ class _$MoneygramSwapResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MoneygramSwapResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -790,6 +848,8 @@ class __$$MoneygramSwapResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$MoneygramSwapResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MoneygramSwapResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -829,11 +889,13 @@ class _$MoneygramSwapResponseDtoImpl implements _MoneygramSwapResponseDto {
                 other.encodedTx == encodedTx));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, encodedTx);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MoneygramSwapResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MoneygramSwapResponseDtoImplCopyWith<_$MoneygramSwapResponseDtoImpl>
@@ -857,8 +919,11 @@ abstract class _MoneygramSwapResponseDto implements MoneygramSwapResponseDto {
 
   @override
   String get encodedTx;
+
+  /// Create a copy of MoneygramSwapResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MoneygramSwapResponseDtoImplCopyWith<_$MoneygramSwapResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -873,8 +938,12 @@ mixin _$MoneygramFeeRequestDto {
   String get amount => throw _privateConstructorUsedError;
   RampTypeDto get type => throw _privateConstructorUsedError;
 
+  /// Serializes this MoneygramFeeRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MoneygramFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MoneygramFeeRequestDtoCopyWith<MoneygramFeeRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -899,6 +968,8 @@ class _$MoneygramFeeRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MoneygramFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -940,6 +1011,8 @@ class __$$MoneygramFeeRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$MoneygramFeeRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MoneygramFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -987,11 +1060,13 @@ class _$MoneygramFeeRequestDtoImpl implements _MoneygramFeeRequestDto {
             (identical(other.type, type) || other.type == type));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, amount, type);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MoneygramFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MoneygramFeeRequestDtoImplCopyWith<_$MoneygramFeeRequestDtoImpl>
@@ -1018,8 +1093,11 @@ abstract class _MoneygramFeeRequestDto implements MoneygramFeeRequestDto {
   String get amount;
   @override
   RampTypeDto get type;
+
+  /// Create a copy of MoneygramFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MoneygramFeeRequestDtoImplCopyWith<_$MoneygramFeeRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1037,8 +1115,12 @@ mixin _$MoneygramFeeResponseDto {
   String? get gasFeeInUsdc => throw _privateConstructorUsedError;
   int? get priorityFee => throw _privateConstructorUsedError;
 
+  /// Serializes this MoneygramFeeResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MoneygramFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MoneygramFeeResponseDtoCopyWith<MoneygramFeeResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1068,6 +1150,8 @@ class _$MoneygramFeeResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MoneygramFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1129,6 +1213,8 @@ class __$$MoneygramFeeResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$MoneygramFeeResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MoneygramFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1209,12 +1295,14 @@ class _$MoneygramFeeResponseDtoImpl implements _MoneygramFeeResponseDto {
                 other.priorityFee == priorityFee));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, totalAmount, bridgeFee,
       moneygramFee, gasFeeInUsdc, priorityFee);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MoneygramFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MoneygramFeeResponseDtoImplCopyWith<_$MoneygramFeeResponseDtoImpl>
@@ -1250,8 +1338,11 @@ abstract class _MoneygramFeeResponseDto implements MoneygramFeeResponseDto {
   String? get gasFeeInUsdc;
   @override
   int? get priorityFee;
+
+  /// Create a copy of MoneygramFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MoneygramFeeResponseDtoImplCopyWith<_$MoneygramFeeResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1264,8 +1355,12 @@ FundXlmRequestDto _$FundXlmRequestDtoFromJson(Map<String, dynamic> json) {
 mixin _$FundXlmRequestDto {
   String get accountId => throw _privateConstructorUsedError;
 
+  /// Serializes this FundXlmRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of FundXlmRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $FundXlmRequestDtoCopyWith<FundXlmRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1289,6 +1384,8 @@ class _$FundXlmRequestDtoCopyWithImpl<$Res, $Val extends FundXlmRequestDto>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of FundXlmRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1322,6 +1419,8 @@ class __$$FundXlmRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$FundXlmRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of FundXlmRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1361,11 +1460,13 @@ class _$FundXlmRequestDtoImpl implements _FundXlmRequestDto {
                 other.accountId == accountId));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, accountId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of FundXlmRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$FundXlmRequestDtoImplCopyWith<_$FundXlmRequestDtoImpl> get copyWith =>
@@ -1389,8 +1490,11 @@ abstract class _FundXlmRequestDto implements FundXlmRequestDto {
 
   @override
   String get accountId;
+
+  /// Create a copy of FundXlmRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$FundXlmRequestDtoImplCopyWith<_$FundXlmRequestDtoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/priority_fees.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/priority_fees.freezed.dart
@@ -23,8 +23,12 @@ PriorityFeesRequestDto _$PriorityFeesRequestDtoFromJson(
 mixin _$PriorityFeesRequestDto {
   String get encodedTx => throw _privateConstructorUsedError;
 
+  /// Serializes this PriorityFeesRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PriorityFeesRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PriorityFeesRequestDtoCopyWith<PriorityFeesRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -49,6 +53,8 @@ class _$PriorityFeesRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PriorityFeesRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -85,6 +91,8 @@ class __$$PriorityFeesRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$PriorityFeesRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PriorityFeesRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -124,11 +132,13 @@ class _$PriorityFeesRequestDtoImpl implements _PriorityFeesRequestDto {
                 other.encodedTx == encodedTx));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, encodedTx);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PriorityFeesRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PriorityFeesRequestDtoImplCopyWith<_$PriorityFeesRequestDtoImpl>
@@ -152,8 +162,11 @@ abstract class _PriorityFeesRequestDto implements PriorityFeesRequestDto {
 
   @override
   String get encodedTx;
+
+  /// Create a copy of PriorityFeesRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PriorityFeesRequestDtoImplCopyWith<_$PriorityFeesRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -172,8 +185,12 @@ mixin _$PriorityFeesResponseDto {
   int? get veryHigh => throw _privateConstructorUsedError;
   int? get unsafeMax => throw _privateConstructorUsedError;
 
+  /// Serializes this PriorityFeesResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PriorityFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PriorityFeesResponseDtoCopyWith<PriorityFeesResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -204,6 +221,8 @@ class _$PriorityFeesResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PriorityFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -271,6 +290,8 @@ class __$$PriorityFeesResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$PriorityFeesResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PriorityFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -357,12 +378,14 @@ class _$PriorityFeesResponseDtoImpl implements _PriorityFeesResponseDto {
                 other.unsafeMax == unsafeMax));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, none, low, medium, high, veryHigh, unsafeMax);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PriorityFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PriorityFeesResponseDtoImplCopyWith<_$PriorityFeesResponseDtoImpl>
@@ -401,8 +424,11 @@ abstract class _PriorityFeesResponseDto implements PriorityFeesResponseDto {
   int? get veryHigh;
   @override
   int? get unsafeMax;
+
+  /// Create a copy of PriorityFeesResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PriorityFeesResponseDtoImplCopyWith<_$PriorityFeesResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/scalex.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/scalex.freezed.dart
@@ -23,8 +23,12 @@ GenerateScalexLinkResponseDto _$GenerateScalexLinkResponseDtoFromJson(
 mixin _$GenerateScalexLinkResponseDto {
   String get signedUrl => throw _privateConstructorUsedError;
 
+  /// Serializes this GenerateScalexLinkResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GenerateScalexLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GenerateScalexLinkResponseDtoCopyWith<GenerateScalexLinkResponseDto>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -51,6 +55,8 @@ class _$GenerateScalexLinkResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GenerateScalexLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -87,6 +93,8 @@ class __$$GenerateScalexLinkResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$GenerateScalexLinkResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GenerateScalexLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -128,11 +136,13 @@ class _$GenerateScalexLinkResponseDtoImpl
                 other.signedUrl == signedUrl));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, signedUrl);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GenerateScalexLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GenerateScalexLinkResponseDtoImplCopyWith<
@@ -158,8 +168,11 @@ abstract class _GenerateScalexLinkResponseDto
 
   @override
   String get signedUrl;
+
+  /// Create a copy of GenerateScalexLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GenerateScalexLinkResponseDtoImplCopyWith<
           _$GenerateScalexLinkResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -178,8 +191,12 @@ mixin _$GenerateScalexLinkRequestDto {
   double? get amount => throw _privateConstructorUsedError;
   String? get currency => throw _privateConstructorUsedError;
 
+  /// Serializes this GenerateScalexLinkRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GenerateScalexLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GenerateScalexLinkRequestDtoCopyWith<GenerateScalexLinkRequestDto>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -211,6 +228,8 @@ class _$GenerateScalexLinkRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GenerateScalexLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -272,6 +291,8 @@ class __$$GenerateScalexLinkRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$GenerateScalexLinkRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GenerateScalexLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -350,12 +371,14 @@ class _$GenerateScalexLinkRequestDtoImpl
                 other.currency == currency));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, type, address, email, amount, currency);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GenerateScalexLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GenerateScalexLinkRequestDtoImplCopyWith<
@@ -393,8 +416,11 @@ abstract class _GenerateScalexLinkRequestDto
   double? get amount;
   @override
   String? get currency;
+
+  /// Create a copy of GenerateScalexLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GenerateScalexLinkRequestDtoImplCopyWith<
           _$GenerateScalexLinkRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -409,8 +435,12 @@ OrderStatusScalexRequestDto _$OrderStatusScalexRequestDtoFromJson(
 mixin _$OrderStatusScalexRequestDto {
   String get referenceId => throw _privateConstructorUsedError;
 
+  /// Serializes this OrderStatusScalexRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OrderStatusScalexRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OrderStatusScalexRequestDtoCopyWith<OrderStatusScalexRequestDto>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -437,6 +467,8 @@ class _$OrderStatusScalexRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OrderStatusScalexRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -473,6 +505,8 @@ class __$$OrderStatusScalexRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$OrderStatusScalexRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OrderStatusScalexRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -514,11 +548,13 @@ class _$OrderStatusScalexRequestDtoImpl
                 other.referenceId == referenceId));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, referenceId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OrderStatusScalexRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OrderStatusScalexRequestDtoImplCopyWith<_$OrderStatusScalexRequestDtoImpl>
@@ -543,8 +579,11 @@ abstract class _OrderStatusScalexRequestDto
 
   @override
   String get referenceId;
+
+  /// Create a copy of OrderStatusScalexRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OrderStatusScalexRequestDtoImplCopyWith<_$OrderStatusScalexRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -560,8 +599,12 @@ mixin _$OrderStatusScalexResponseDto {
   ScalexOrderStatus get status => throw _privateConstructorUsedError;
   OnRampScalexDetails? get onRampDetails => throw _privateConstructorUsedError;
 
+  /// Serializes this OrderStatusScalexResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OrderStatusScalexResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OrderStatusScalexResponseDtoCopyWith<OrderStatusScalexResponseDto>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -593,6 +636,8 @@ class _$OrderStatusScalexResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OrderStatusScalexResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -611,6 +656,8 @@ class _$OrderStatusScalexResponseDtoCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of OrderStatusScalexResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $OnRampScalexDetailsCopyWith<$Res>? get onRampDetails {
@@ -652,6 +699,8 @@ class __$$OrderStatusScalexResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$OrderStatusScalexResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OrderStatusScalexResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -705,11 +754,13 @@ class _$OrderStatusScalexResponseDtoImpl
                 other.onRampDetails == onRampDetails));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, status, onRampDetails);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OrderStatusScalexResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OrderStatusScalexResponseDtoImplCopyWith<
@@ -741,8 +792,11 @@ abstract class _OrderStatusScalexResponseDto
   ScalexOrderStatus get status;
   @override
   OnRampScalexDetails? get onRampDetails;
+
+  /// Create a copy of OrderStatusScalexResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OrderStatusScalexResponseDtoImplCopyWith<
           _$OrderStatusScalexResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -758,8 +812,12 @@ mixin _$ScalexWithdrawRequestDto {
   String get orderId => throw _privateConstructorUsedError;
   Cluster get cluster => throw _privateConstructorUsedError;
 
+  /// Serializes this ScalexWithdrawRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ScalexWithdrawRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ScalexWithdrawRequestDtoCopyWith<ScalexWithdrawRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -784,6 +842,8 @@ class _$ScalexWithdrawRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ScalexWithdrawRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -825,6 +885,8 @@ class __$$ScalexWithdrawRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$ScalexWithdrawRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ScalexWithdrawRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -872,11 +934,13 @@ class _$ScalexWithdrawRequestDtoImpl implements _ScalexWithdrawRequestDto {
             (identical(other.cluster, cluster) || other.cluster == cluster));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, orderId, cluster);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ScalexWithdrawRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ScalexWithdrawRequestDtoImplCopyWith<_$ScalexWithdrawRequestDtoImpl>
@@ -903,8 +967,11 @@ abstract class _ScalexWithdrawRequestDto implements ScalexWithdrawRequestDto {
   String get orderId;
   @override
   Cluster get cluster;
+
+  /// Create a copy of ScalexWithdrawRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ScalexWithdrawRequestDtoImplCopyWith<_$ScalexWithdrawRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -920,8 +987,12 @@ mixin _$ScalexWithdrawResponseDto {
   String get transaction => throw _privateConstructorUsedError;
   BigInt get slot => throw _privateConstructorUsedError;
 
+  /// Serializes this ScalexWithdrawResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ScalexWithdrawResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ScalexWithdrawResponseDtoCopyWith<ScalexWithdrawResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -946,6 +1017,8 @@ class _$ScalexWithdrawResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ScalexWithdrawResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -992,6 +1065,8 @@ class __$$WithdrawPaymentResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$WithdrawPaymentResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ScalexWithdrawResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1049,11 +1124,13 @@ class _$WithdrawPaymentResponseDtoImpl implements _WithdrawPaymentResponseDto {
             (identical(other.slot, slot) || other.slot == slot));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, fee, transaction, slot);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ScalexWithdrawResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$WithdrawPaymentResponseDtoImplCopyWith<_$WithdrawPaymentResponseDtoImpl>
@@ -1084,8 +1161,11 @@ abstract class _WithdrawPaymentResponseDto
   String get transaction;
   @override
   BigInt get slot;
+
+  /// Create a copy of ScalexWithdrawResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$WithdrawPaymentResponseDtoImplCopyWith<_$WithdrawPaymentResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1102,8 +1182,12 @@ mixin _$OnRampScalexDetails {
   num get fromAmount => throw _privateConstructorUsedError;
   String get fiatCurrency => throw _privateConstructorUsedError;
 
+  /// Serializes this OnRampScalexDetails to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OnRampScalexDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OnRampScalexDetailsCopyWith<OnRampScalexDetails> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1132,6 +1216,8 @@ class _$OnRampScalexDetailsCopyWithImpl<$Res, $Val extends OnRampScalexDetails>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OnRampScalexDetails
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1190,6 +1276,8 @@ class __$$OnRampScalexDetailsImplCopyWithImpl<$Res>
       $Res Function(_$OnRampScalexDetailsImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OnRampScalexDetails
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1270,12 +1358,14 @@ class _$OnRampScalexDetailsImpl implements _OnRampScalexDetails {
                 other.fiatCurrency == fiatCurrency));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, currency, bankName, bankAccount, fromAmount, fiatCurrency);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OnRampScalexDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OnRampScalexDetailsImplCopyWith<_$OnRampScalexDetailsImpl> get copyWith =>
@@ -1311,8 +1401,11 @@ abstract class _OnRampScalexDetails implements OnRampScalexDetails {
   num get fromAmount;
   @override
   String get fiatCurrency;
+
+  /// Create a copy of OnRampScalexDetails
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OnRampScalexDetailsImplCopyWith<_$OnRampScalexDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1332,8 +1425,12 @@ mixin _$ScalexRateFeeResponseDto {
   double? get fixedOnRampFee => throw _privateConstructorUsedError;
   double get espressoFeePercentage => throw _privateConstructorUsedError;
 
+  /// Serializes this ScalexRateFeeResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ScalexRateFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ScalexRateFeeResponseDtoCopyWith<ScalexRateFeeResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1365,6 +1462,8 @@ class _$ScalexRateFeeResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ScalexRateFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1438,6 +1537,8 @@ class __$$ScalexRateFeeResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$ScalexRateFeeResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ScalexRateFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1538,7 +1639,7 @@ class _$ScalexRateFeeResponseDtoImpl implements _ScalexRateFeeResponseDto {
                 other.espressoFeePercentage == espressoFeePercentage));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -1550,7 +1651,9 @@ class _$ScalexRateFeeResponseDtoImpl implements _ScalexRateFeeResponseDto {
       fixedOnRampFee,
       espressoFeePercentage);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ScalexRateFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ScalexRateFeeResponseDtoImplCopyWith<_$ScalexRateFeeResponseDtoImpl>
@@ -1593,8 +1696,11 @@ abstract class _ScalexRateFeeResponseDto implements ScalexRateFeeResponseDto {
   double? get fixedOnRampFee;
   @override
   double get espressoFeePercentage;
+
+  /// Create a copy of ScalexRateFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ScalexRateFeeResponseDtoImplCopyWith<_$ScalexRateFeeResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1609,8 +1715,12 @@ mixin _$ScalexBrijFeeRequestDto {
   String get amount => throw _privateConstructorUsedError;
   RampTypeDto get type => throw _privateConstructorUsedError;
 
+  /// Serializes this ScalexBrijFeeRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ScalexBrijFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ScalexBrijFeeRequestDtoCopyWith<ScalexBrijFeeRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1635,6 +1745,8 @@ class _$ScalexBrijFeeRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ScalexBrijFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1676,6 +1788,8 @@ class __$$ScalexBrijFeeRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$ScalexBrijFeeRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ScalexBrijFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1723,11 +1837,13 @@ class _$ScalexBrijFeeRequestDtoImpl implements _ScalexBrijFeeRequestDto {
             (identical(other.type, type) || other.type == type));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, amount, type);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ScalexBrijFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ScalexBrijFeeRequestDtoImplCopyWith<_$ScalexBrijFeeRequestDtoImpl>
@@ -1754,8 +1870,11 @@ abstract class _ScalexBrijFeeRequestDto implements ScalexBrijFeeRequestDto {
   String get amount;
   @override
   RampTypeDto get type;
+
+  /// Create a copy of ScalexBrijFeeRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ScalexBrijFeeRequestDtoImplCopyWith<_$ScalexBrijFeeRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1772,8 +1891,12 @@ mixin _$ScalexFees {
   double get percentageFeeAmount => throw _privateConstructorUsedError;
   double get totalFee => throw _privateConstructorUsedError;
 
+  /// Serializes this ScalexFees to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ScalexFees
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ScalexFeesCopyWith<ScalexFees> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1802,6 +1925,8 @@ class _$ScalexFeesCopyWithImpl<$Res, $Val extends ScalexFees>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ScalexFees
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1860,6 +1985,8 @@ class __$$ScalexFeesImplCopyWithImpl<$Res>
       _$ScalexFeesImpl _value, $Res Function(_$ScalexFeesImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ScalexFees
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1940,12 +2067,14 @@ class _$ScalexFeesImpl implements _ScalexFees {
                 other.totalFee == totalFee));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, fixedFee, marginFee,
       percentageFee, percentageFeeAmount, totalFee);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ScalexFees
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ScalexFeesImplCopyWith<_$ScalexFeesImpl> get copyWith =>
@@ -1980,8 +2109,11 @@ abstract class _ScalexFees implements ScalexFees {
   double get percentageFeeAmount;
   @override
   double get totalFee;
+
+  /// Create a copy of ScalexFees
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ScalexFeesImplCopyWith<_$ScalexFeesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1998,8 +2130,12 @@ mixin _$ScalexBrijFeeResponseDto {
   double get rate => throw _privateConstructorUsedError;
   ScalexFees get scalexFees => throw _privateConstructorUsedError;
 
+  /// Serializes this ScalexBrijFeeResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ScalexBrijFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ScalexBrijFeeResponseDtoCopyWith<ScalexBrijFeeResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2030,6 +2166,8 @@ class _$ScalexBrijFeeResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ScalexBrijFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2058,6 +2196,8 @@ class _$ScalexBrijFeeResponseDtoCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of ScalexBrijFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ScalexFeesCopyWith<$Res> get scalexFees {
@@ -2096,6 +2236,8 @@ class __$$ScalexBrijFeeResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$ScalexBrijFeeResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ScalexBrijFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2165,12 +2307,14 @@ class _$ScalexBrijFeeResponseDtoImpl implements _ScalexBrijFeeResponseDto {
                 other.scalexFees == scalexFees));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, fiatAmount, cryptoAmount, rate, scalexFees);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ScalexBrijFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ScalexBrijFeeResponseDtoImplCopyWith<_$ScalexBrijFeeResponseDtoImpl>
@@ -2203,8 +2347,11 @@ abstract class _ScalexBrijFeeResponseDto implements ScalexBrijFeeResponseDto {
   double get rate;
   @override
   ScalexFees get scalexFees;
+
+  /// Create a copy of ScalexBrijFeeResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ScalexBrijFeeResponseDtoImplCopyWith<_$ScalexBrijFeeResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/shorten_link.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/shorten_link.freezed.dart
@@ -23,8 +23,12 @@ ShortenLinkRequestDto _$ShortenLinkRequestDtoFromJson(
 mixin _$ShortenLinkRequestDto {
   String get fullLink => throw _privateConstructorUsedError;
 
+  /// Serializes this ShortenLinkRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ShortenLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ShortenLinkRequestDtoCopyWith<ShortenLinkRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -49,6 +53,8 @@ class _$ShortenLinkRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ShortenLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -84,6 +90,8 @@ class __$$ShortenLinkRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$ShortenLinkRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ShortenLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -123,11 +131,13 @@ class _$ShortenLinkRequestDtoImpl implements _ShortenLinkRequestDto {
                 other.fullLink == fullLink));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, fullLink);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ShortenLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ShortenLinkRequestDtoImplCopyWith<_$ShortenLinkRequestDtoImpl>
@@ -151,8 +161,11 @@ abstract class _ShortenLinkRequestDto implements ShortenLinkRequestDto {
 
   @override
   String get fullLink;
+
+  /// Create a copy of ShortenLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ShortenLinkRequestDtoImplCopyWith<_$ShortenLinkRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -166,8 +179,12 @@ ShortenLinkResponseDto _$ShortenLinkResponseDtoFromJson(
 mixin _$ShortenLinkResponseDto {
   String get shortLink => throw _privateConstructorUsedError;
 
+  /// Serializes this ShortenLinkResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ShortenLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ShortenLinkResponseDtoCopyWith<ShortenLinkResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -192,6 +209,8 @@ class _$ShortenLinkResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ShortenLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -228,6 +247,8 @@ class __$$ShortenLinkResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$ShortenLinkResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ShortenLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -267,11 +288,13 @@ class _$ShortenLinkResponseDtoImpl implements _ShortenLinkResponseDto {
                 other.shortLink == shortLink));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, shortLink);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ShortenLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ShortenLinkResponseDtoImplCopyWith<_$ShortenLinkResponseDtoImpl>
@@ -295,8 +318,11 @@ abstract class _ShortenLinkResponseDto implements ShortenLinkResponseDto {
 
   @override
   String get shortLink;
+
+  /// Create a copy of ShortenLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ShortenLinkResponseDtoImplCopyWith<_$ShortenLinkResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -310,8 +336,12 @@ UnshortenLinkRequestDto _$UnshortenLinkRequestDtoFromJson(
 mixin _$UnshortenLinkRequestDto {
   String get shortLink => throw _privateConstructorUsedError;
 
+  /// Serializes this UnshortenLinkRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UnshortenLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UnshortenLinkRequestDtoCopyWith<UnshortenLinkRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -336,6 +366,8 @@ class _$UnshortenLinkRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UnshortenLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -372,6 +404,8 @@ class __$$UnshortenLinkRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$UnshortenLinkRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UnshortenLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -411,11 +445,13 @@ class _$UnshortenLinkRequestDtoImpl implements _UnshortenLinkRequestDto {
                 other.shortLink == shortLink));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, shortLink);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UnshortenLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UnshortenLinkRequestDtoImplCopyWith<_$UnshortenLinkRequestDtoImpl>
@@ -439,8 +475,11 @@ abstract class _UnshortenLinkRequestDto implements UnshortenLinkRequestDto {
 
   @override
   String get shortLink;
+
+  /// Create a copy of UnshortenLinkRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UnshortenLinkRequestDtoImplCopyWith<_$UnshortenLinkRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -454,8 +493,12 @@ UnshortenLinkResponseDto _$UnshortenLinkResponseDtoFromJson(
 mixin _$UnshortenLinkResponseDto {
   String get fullLink => throw _privateConstructorUsedError;
 
+  /// Serializes this UnshortenLinkResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UnshortenLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UnshortenLinkResponseDtoCopyWith<UnshortenLinkResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -480,6 +523,8 @@ class _$UnshortenLinkResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UnshortenLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -516,6 +561,8 @@ class __$$UnshortenLinkResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$UnshortenLinkResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UnshortenLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -555,11 +602,13 @@ class _$UnshortenLinkResponseDtoImpl implements _UnshortenLinkResponseDto {
                 other.fullLink == fullLink));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, fullLink);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UnshortenLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UnshortenLinkResponseDtoImplCopyWith<_$UnshortenLinkResponseDtoImpl>
@@ -583,8 +632,11 @@ abstract class _UnshortenLinkResponseDto implements UnshortenLinkResponseDto {
 
   @override
   String get fullLink;
+
+  /// Create a copy of UnshortenLinkResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UnshortenLinkResponseDtoImplCopyWith<_$UnshortenLinkResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/swap.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/swap.freezed.dart
@@ -28,8 +28,12 @@ mixin _$SwapRouteRequestDto {
   String get userAccount => throw _privateConstructorUsedError;
   bool get asLegacyTx => throw _privateConstructorUsedError;
 
+  /// Serializes this SwapRouteRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SwapRouteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SwapRouteRequestDtoCopyWith<SwapRouteRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -60,6 +64,8 @@ class _$SwapRouteRequestDtoCopyWithImpl<$Res, $Val extends SwapRouteRequestDto>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SwapRouteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -130,6 +136,8 @@ class __$$SwapRouteRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$SwapRouteRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SwapRouteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -229,12 +237,14 @@ class _$SwapRouteRequestDtoImpl implements _SwapRouteRequestDto {
                 other.asLegacyTx == asLegacyTx));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, inputToken, outputToken, amount,
       match, slippage, userAccount, asLegacyTx);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SwapRouteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SwapRouteRequestDtoImplCopyWith<_$SwapRouteRequestDtoImpl> get copyWith =>
@@ -276,8 +286,11 @@ abstract class _SwapRouteRequestDto implements SwapRouteRequestDto {
   String get userAccount;
   @override
   bool get asLegacyTx;
+
+  /// Create a copy of SwapRouteRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SwapRouteRequestDtoImplCopyWith<_$SwapRouteRequestDtoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -295,8 +308,12 @@ mixin _$SwapRouteResponseDto {
   int get feeInUsdc => throw _privateConstructorUsedError;
   BigInt get slot => throw _privateConstructorUsedError;
 
+  /// Serializes this SwapRouteResponseDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SwapRouteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SwapRouteResponseDtoCopyWith<SwapRouteResponseDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -327,6 +344,8 @@ class _$SwapRouteResponseDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SwapRouteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -391,6 +410,8 @@ class __$$SwapRouteResponseDtoImplCopyWithImpl<$Res>
       $Res Function(_$SwapRouteResponseDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SwapRouteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -479,12 +500,14 @@ class _$SwapRouteResponseDtoImpl implements _SwapRouteResponseDto {
             (identical(other.slot, slot) || other.slot == slot));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, inAmount, outAmount, amount, encodedTx, feeInUsdc, slot);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SwapRouteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SwapRouteResponseDtoImplCopyWith<_$SwapRouteResponseDtoImpl>
@@ -524,8 +547,11 @@ abstract class _SwapRouteResponseDto implements SwapRouteResponseDto {
   int get feeInUsdc;
   @override
   BigInt get slot;
+
+  /// Create a copy of SwapRouteResponseDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SwapRouteResponseDtoImplCopyWith<_$SwapRouteResponseDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/lib/src/dto/user.freezed.dart
+++ b/packages/espressocash_api/lib/src/dto/user.freezed.dart
@@ -23,8 +23,12 @@ WalletCountryRequestDto _$WalletCountryRequestDtoFromJson(
 mixin _$WalletCountryRequestDto {
   String get countryCode => throw _privateConstructorUsedError;
 
+  /// Serializes this WalletCountryRequestDto to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of WalletCountryRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $WalletCountryRequestDtoCopyWith<WalletCountryRequestDto> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -49,6 +53,8 @@ class _$WalletCountryRequestDtoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of WalletCountryRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -85,6 +91,8 @@ class __$$WalletCountryRequestDtoImplCopyWithImpl<$Res>
       $Res Function(_$WalletCountryRequestDtoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of WalletCountryRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -124,11 +132,13 @@ class _$WalletCountryRequestDtoImpl implements _WalletCountryRequestDto {
                 other.countryCode == countryCode));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, countryCode);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of WalletCountryRequestDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$WalletCountryRequestDtoImplCopyWith<_$WalletCountryRequestDtoImpl>
@@ -152,8 +162,11 @@ abstract class _WalletCountryRequestDto implements WalletCountryRequestDto {
 
   @override
   String get countryCode;
+
+  /// Create a copy of WalletCountryRequestDto
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$WalletCountryRequestDtoImplCopyWith<_$WalletCountryRequestDtoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/espressocash_api/pubspec.yaml
+++ b/packages/espressocash_api/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   dio: ^5.4.0

--- a/packages/espressocash_api/pubspec.yaml
+++ b/packages/espressocash_api/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
   freezed: ^2.0.2
   json_serializable: ^6.3.1
   mews_pedantic: ^0.27.0
-  retrofit_generator: ^8.0.6
+  retrofit_generator: ">=8.0.6 <10.0.0"

--- a/packages/espressocash_api/pubspec.yaml
+++ b/packages/espressocash_api/pubspec.yaml
@@ -20,5 +20,5 @@ dev_dependencies:
   build_runner: ^2.1.10
   freezed: ^2.0.2
   json_serializable: ^6.3.1
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
   retrofit_generator: ^8.0.6

--- a/packages/espressocash_app/analysis_options.yaml
+++ b/packages/espressocash_app/analysis_options.yaml
@@ -16,6 +16,7 @@ analyzer:
   errors:
     always_use_package_imports: ignore
     avoid_relative_lib_imports: ignore
+    deprecated_member_use: ignore
     deprecated_member_use_from_same_package: ignore
 
 dart_code_metrics:

--- a/packages/espressocash_app/lib/features/conversion_rates/data/jupiter_client.dart
+++ b/packages/espressocash_app/lib/features/conversion_rates/data/jupiter_client.dart
@@ -3,6 +3,7 @@ import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:retrofit/dio.dart';
+import 'package:retrofit/error_logger.dart';
 import 'package:retrofit/http.dart';
 
 import 'cache_client.dart';

--- a/packages/espressocash_app/lib/features/conversion_rates/data/jupiter_client.dart
+++ b/packages/espressocash_app/lib/features/conversion_rates/data/jupiter_client.dart
@@ -2,9 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
-import 'package:retrofit/dio.dart';
-import 'package:retrofit/error_logger.dart';
-import 'package:retrofit/http.dart';
+import 'package:retrofit/retrofit.dart';
 
 import 'cache_client.dart';
 

--- a/packages/espressocash_app/lib/features/ramp/partners/kado/data/kado_api_client.dart
+++ b/packages/espressocash_app/lib/features/ramp/partners/kado/data/kado_api_client.dart
@@ -3,6 +3,7 @@
 import 'package:dio/dio.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
+import 'package:retrofit/error_logger.dart';
 import 'package:retrofit/http.dart';
 
 import '../../../../../../config.dart';

--- a/packages/espressocash_app/lib/features/ramp/partners/kado/data/kado_api_client.dart
+++ b/packages/espressocash_app/lib/features/ramp/partners/kado/data/kado_api_client.dart
@@ -3,8 +3,7 @@
 import 'package:dio/dio.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
-import 'package:retrofit/error_logger.dart';
-import 'package:retrofit/http.dart';
+import 'package:retrofit/retrofit.dart';
 
 import '../../../../../../config.dart';
 

--- a/packages/espressocash_app/lib/features/ramp/partners/moneygram/data/allbridge_client.dart
+++ b/packages/espressocash_app/lib/features/ramp/partners/moneygram/data/allbridge_client.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
-import 'package:retrofit/http.dart';
 import 'package:retrofit/retrofit.dart';
 
 import 'allbridge_dto.dart';

--- a/packages/espressocash_app/pubspec.lock
+++ b/packages/espressocash_app/pubspec.lock
@@ -38,6 +38,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.11.0"
+  analyzer_plugin:
+    dependency: transitive
+    description:
+      name: analyzer_plugin
+      sha256: "9661b30b13a685efaee9f02e5d01ed9f2b423bd889d28a304d02d704aee69161"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.3"
   ansicolor:
     dependency: transitive
     description:
@@ -504,18 +512,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: ab4d0e7aa1793829b1dd8e72d71bbf0b53bf4ff84b184045d1ab71b0832e632e
+      sha256: b50a8342c6ddf05be53bda1d246404cbad101b64dc73e8d6d1ac1090d119b4e2
       url: "https://pub.dev"
     source: hosted
-    version: "2.25.0"
+    version: "2.15.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "6c559daf45dd9588eb88d8de7038b9826d404c2163850c6ebad008ba0ec1b9f7"
+      sha256: c037d9431b6f8dc633652b1469e5f53aaec6e4eb405ed29dd232fa888ef10d88
       url: "https://pub.dev"
     source: hosted
-    version: "2.25.1"
+    version: "2.15.0"
   ed25519_edwards:
     dependency: transitive
     description:
@@ -1974,10 +1982,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "27dd0a9f0c02e22ac0eb42a23df9ea079ce69b52bb4a3b478d64e0ef34a263ee"
+      sha256: "7b20045d1ccfb7bc1df7e8f9fee5ae58673fce6ff62cefbb0e0fd7214e90e5a0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.41.0"
+    version: "0.34.1"
   stack_trace:
     dependency: transitive
     description:

--- a/packages/espressocash_app/pubspec.lock
+++ b/packages/espressocash_app/pubspec.lock
@@ -5,18 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "61.0.0"
+    version: "76.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "9371d13b8ee442e3bfc08a24e3a1b3742c839abbfaf5eef11b79c4b862c89bf7"
+      sha256: e051259913915ea5bc8fe18664596bea08592fd123930605d562969cd7315fcd
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.41"
+    version: "1.3.51"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.3"
   adaptive_number:
     dependency: transitive
     description:
@@ -29,18 +34,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
-  analyzer_plugin:
-    dependency: transitive
-    description:
-      name: analyzer_plugin
-      sha256: c1d5f167683de03d5ab6c3b53fc9aeefc5d59476e7810ba7bbddff50c6f4392d
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.11.2"
+    version: "6.11.0"
   ansicolor:
     dependency: transitive
     description:
@@ -53,18 +50,18 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: "6199c74e3db4fbfbd04f66d739e72fe11c8a8957d5f219f1f4482dbde6420b5a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.2"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.0"
   async:
     dependency: "direct main"
     description:
@@ -77,10 +74,10 @@ packages:
     dependency: transitive
     description:
       name: barcode
-      sha256: ab180ce22c6555d77d45f0178a523669db67f95856e3378259ef2ffeb43e6003
+      sha256: "7b6729c37e3b7f34233e2318d866e8c48ddb46c1f7ad01ff7bb2a8de1da2b9f4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.8"
+    version: "2.2.9"
   barcode_widget:
     dependency: "direct main"
     description:
@@ -140,18 +137,16 @@ packages:
   borsh:
     dependency: "direct dev"
     description:
-      name: borsh
-      sha256: "5bf90ea0e7a6dca4b482f1ba710753334250e062072e33477ce0a9d82f5fcfcf"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../borsh"
+      relative: true
+    source: path
     version: "0.3.1+4"
   borsh_annotation:
     dependency: "direct main"
     description:
-      name: borsh_annotation
-      sha256: "4a226cf8b7a165ecf8020c0c8d366b2728167fd102ef9b9e89d94d86f89ac57b"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../borsh_annotation"
+      relative: true
+    source: path
     version: "0.3.1+5"
   bs58:
     dependency: transitive
@@ -165,50 +160,50 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.11"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.1"
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -221,18 +216,18 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
+      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.2"
+    version: "8.9.3"
   cached_network_image:
     dependency: "direct main"
     description:
       name: cached_network_image
-      sha256: "4a5d8d2c728b0f3d0245f69f921d7be90cae4c2fd5288f773088672c0893f819"
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.4.1"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
@@ -245,42 +240,42 @@ packages:
     dependency: transitive
     description:
       name: cached_network_image_web
-      sha256: "6322dde7a5ad92202e64df659241104a43db20ed594c41ca18de1014598d7996"
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   camera:
     dependency: transitive
     description:
       name: camera
-      sha256: "26ff41045772153f222ffffecba711a206f670f5834d40ebf5eed3811692f167"
+      sha256: "413d2b34fe28496c35c69ede5b232fb9dd5ca2c3a4cb606b14efc1c7546cc8cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.0+2"
+    version: "0.11.1"
   camera_android_camerax:
     dependency: transitive
     description:
       name: camera_android_camerax
-      sha256: "011be2ab0e5b3e3aa8094413fa890f8c5c5afd7cfdaef353a992047d4dab5780"
+      sha256: "7cc6adf1868bdcf4e63a56b24b41692dfbad2bec1cdceea451c77798f6a605c3"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8+2"
+    version: "0.6.13"
   camera_avfoundation:
     dependency: transitive
     description:
       name: camera_avfoundation
-      sha256: "7c28969a975a7eb2349bc2cb2dfe3ad218a33dba9968ecfb181ce08c87486655"
+      sha256: "49cc403dc2aec719cc70ba23419c932f1245d990e43f3c8336014b895751454a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.17+3"
+    version: "0.9.18+4"
   camera_platform_interface:
     dependency: transitive
     description:
       name: camera_platform_interface
-      sha256: b3ede1f171532e0d83111fe0980b46d17f1aa9788a07a2fbed07366bbdbb9061
+      sha256: "953e7baed3a7c8fae92f7200afeb2be503ff1a17c3b4e4ed7b76f008c2810a31"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.0"
+    version: "2.9.0"
   camera_web:
     dependency: transitive
     description:
@@ -301,10 +296,10 @@ packages:
     dependency: transitive
     description:
       name: charcode
-      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -317,10 +312,10 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   clock:
     dependency: transitive
     description:
@@ -333,18 +328,18 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.0"
+    version: "4.10.1"
   collection:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   color:
     dependency: transitive
     description:
@@ -357,26 +352,26 @@ packages:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   country_flags:
     dependency: "direct main"
     description:
       name: country_flags
-      sha256: "0c2d9f0673ad0a5ec148f5b264c9e7338208b83000336bb4db8d189cd50df2bb"
+      sha256: "66726c7070d60c2f90c4a1d58980e9188fa04335d6287e98aef835461019c3c2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.0"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      sha256: c1fb2dce3c0085f39dc72668e85f8e0210ec7de05345821ff58530567df345a5
+      sha256: e3493833ea012784c740e341952298f1cc77f1f01b1bbc3eb4eecf6984fb7f43
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.2"
+    version: "1.11.1"
   cross_file:
     dependency: transitive
     description:
@@ -389,10 +384,10 @@ packages:
     dependency: "direct main"
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   cryptography:
     dependency: transitive
     description:
@@ -405,26 +400,26 @@ packages:
     dependency: transitive
     description:
       name: csslib
-      sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   dart_jsonwebtoken:
     dependency: "direct main"
     description:
       name: dart_jsonwebtoken
-      sha256: "346e9a21e4bf6e6a431e19ece00ebb2e3668e1e339cabdf6f46d18d88692a848"
+      sha256: "00a0812d2aeaeb0d30bcbc4dd3cee57971dbc0ab2216adf4f0247f37793f15ef"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.17.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+      sha256: "7306ab8a2359a48d22310ad823521d723acfed60ee1f7e37388e8986853b6820"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.8"
   dartx:
     dependency: transitive
     description:
@@ -477,18 +472,18 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "5598aa796bbf4699afd5c67c0f5f6e2ed542afc956884b9cd58c306966efc260"
+      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.0"
+    version: "5.8.0+1"
   dio_cache_interceptor:
     dependency: "direct main"
     description:
       name: dio_cache_interceptor
-      sha256: fb7905c0d12075d8786a6b63bffd64ae062d053f682cfaf28d145a2686507308
+      sha256: "1346705a2057c265014d7696e3e2318b560bfb00b484dac7f9b01e2ceaebb07d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.0"
+    version: "3.5.1"
   dio_cache_interceptor_db_store:
     dependency: "direct main"
     description:
@@ -501,26 +496,26 @@ packages:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "33259a9276d6cea88774a0000cfae0d861003497755969c92faa223108620dc8"
+      sha256: e485c7a39ff2b384fa1d7e09b4e25f755804de8384358049124830b04fc4f93a
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   drift:
     dependency: "direct main"
     description:
       name: drift
-      sha256: b50a8342c6ddf05be53bda1d246404cbad101b64dc73e8d6d1ac1090d119b4e2
+      sha256: ab4d0e7aa1793829b1dd8e72d71bbf0b53bf4ff84b184045d1ab71b0832e632e
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.25.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: c037d9431b6f8dc633652b1469e5f53aaec6e4eb405ed29dd232fa888ef10d88
+      sha256: "6c559daf45dd9588eb88d8de7038b9826d404c2163850c6ebad008ba0ec1b9f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.25.1"
   ed25519_edwards:
     dependency: transitive
     description:
@@ -533,10 +528,10 @@ packages:
     dependency: transitive
     description:
       name: ed25519_hd_key
-      sha256: "0d3a58aa81474bfa9ff67b0d8252d73890276be9801cfccf5f1e1bb6b92ac5c6"
+      sha256: "31e191ec97492873067e46dc9cc0c7d55170559c83a478400feffa0627acaccf"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.0"
   espressocash_api:
     dependency: "direct main"
     description:
@@ -556,10 +551,10 @@ packages:
     dependency: "direct main"
     description:
       name: face_camera
-      sha256: "002b95b4c12472c8a652589620bf1f620f82ba7473dba923f978d14b9cd66b86"
+      sha256: f386abf51935efd943b0a9c71ffe01071dd460d606a2d420fa1c58cdd0d57ab0
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.4"
   fake_async:
     dependency: transitive
     description:
@@ -596,18 +591,18 @@ packages:
     dependency: transitive
     description:
       name: file_selector_linux
-      sha256: "045d372bf19b02aeb69cacf8b4009555fb5f6f0b7ad8016e5f46dd1387ddd492"
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.2+1"
+    version: "0.9.3+2"
   file_selector_macos:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: f42eacb83b318e183b1ae24eead1373ab1334084404c8c16e0354f9a3e55d385
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4"
+    version: "0.9.4+2"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -620,90 +615,90 @@ packages:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: "2ad726953f6e8affbc4df8dc78b77c3b4a060967a291e528ef72ae846c60fb69"
+      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+2"
+    version: "0.9.3+3"
   firebase_app_installations:
     dependency: "direct main"
     description:
       name: firebase_app_installations
-      sha256: "4c5b9aaa2e47e43093dc70e9ea908b89f9bcb17fcb9868da446bf5e2a1830d25"
+      sha256: "8aed716c98e15c529f66544008b52d61c6f09888c21696a84ad3b31647f7b2c5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1+1"
+    version: "0.3.2+2"
   firebase_app_installations_platform_interface:
     dependency: transitive
     description:
       name: firebase_app_installations_platform_interface
-      sha256: "70cfa6e2257df9bc1df70710cc2ce9d7581123f281ff26dabbb31218bdc95e76"
+      sha256: "3e3a7a3444e52578f99160078d2723fca44d0e0888138c41ace918de6c90fcaa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4+41"
+    version: "0.1.4+50"
   firebase_app_installations_web:
     dependency: transitive
     description:
       name: firebase_app_installations_web
-      sha256: "74911ba3644c38993cb92760ddaa23cc9389c30b089bbb7700c51b4a7192d894"
+      sha256: "3beab3774036fe9896c4474907f02b87beb6829a71bae369aa4d9ef5d75c686b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.5+13"
+    version: "0.1.6+8"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "06537da27db981947fa535bb91ca120b4e9cb59cb87278dbdde718558cafc9ff"
+      sha256: "93dc4dd12f9b02c5767f235307f609e61ed9211047132d07f9e02c668f0bfc33"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.11.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: f7d7180c7f99babd4b4c517754d41a09a4943a0f7a69b65c894ca5c68ba66315
+      sha256: d7253d255ff10f85cfd2adaba9ac17bae878fa3ba577462451163bd9f1d1f0bf
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.1"
+    version: "5.4.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: f4ee170441ca141c5f9ee5ad8737daba3ee9c8e7efb6902aee90b4fbd178ce25
+      sha256: "0e13c80f0de8acaa5d0519cbe23c8b4cc138a2d5d508b5755c861bdfc9762678"
       url: "https://pub.dev"
     source: hosted
-    version: "2.18.0"
+    version: "2.20.0"
   firebase_remote_config:
     dependency: "direct main"
     description:
       name: firebase_remote_config
-      sha256: b5c23fb7f5b8fd2338f512587a8d2714b5b81dc02508a1c16163c51c1aa41991
+      sha256: "5cfc2d26bb8caba2bfeeb88cbf589cb1c00031eb783019f37c36e12381b8d9ca"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "5.4.0"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:
       name: firebase_remote_config_platform_interface
-      sha256: "127ebc8b7c905d211396cab3b0984e4436c6350400805d196607043b8984d09c"
+      sha256: "79627889fe98b989825e23154f0c6392f9d463b4e39945b27953b34941109fca"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.41"
+    version: "1.5.0"
   firebase_remote_config_web:
     dependency: transitive
     description:
       name: firebase_remote_config_web
-      sha256: "29dbff195c6225f957af541d325426f1697710ac36d169431c95bc92d985f4d2"
+      sha256: d5c999f9398f454ca1e60d3410df6b2a268ff532e6146303aa9dd7b43434afe3
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.13"
+    version: "1.8.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -734,18 +729,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_gen_core
-      sha256: "638d518897f1aefc55a24278968027591d50223a6943b6ae9aa576fe1494d99d"
+      sha256: "53890b653738f34363d9f0d40f82104c261716bd551d3ba65f648770b6764c21"
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.0"
+    version: "5.9.0"
   flutter_gen_runner:
     dependency: "direct dev"
     description:
       name: flutter_gen_runner
-      sha256: "7f2f02d95e3ec96cf70a1c515700c0dd3ea905af003303a55d6fb081240e6b8a"
+      sha256: de70b42eb5329f712c8b041069d081ad5fb5109f32d6d1ea9c1b39596786215d
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.0"
+    version: "5.9.0"
   flutter_inappwebview:
     dependency: "direct main"
     description:
@@ -767,10 +762,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_inappwebview_internal_annotations
-      sha256: "5f80fd30e208ddded7dbbcd0d569e7995f9f63d45ea3f548d8dd4c0b473fb4c8"
+      sha256: "787171d43f8af67864740b6f04166c13190aa74a1468a1f1f1e9ee5b90c359cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   flutter_inappwebview_ios:
     dependency: transitive
     description:
@@ -820,26 +815,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: a23c41ee57573e62fc2190a1f36a0480c4d90bde3a8a8d7126e5d5992fb53fb7
+      sha256: e7bbc718adc9476aa14cfddc1ef048d2e21e4e8f18311aaac723266db9f9e7b5
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3+1"
+    version: "0.7.6+2"
   flutter_native_splash:
     dependency: "direct dev"
     description:
       name: flutter_native_splash
-      sha256: aa06fec78de2190f3db4319dd60fdc8d12b2626e93ef9828633928c2dcaea840
+      sha256: "7062602e0dbd29141fb8eb19220b5871ca650be5197ab9c1f193a28b17537bc7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.4"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "9ee02950848f61c4129af3d6ec84a1cfc0e47931abc746b03e7a3bc3e8ff6eda"
+      sha256: "615a505aef59b151b46bbeef55b36ce2b6ed299d160c51d84281946f0aa0ce0e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.22"
+    version: "2.0.24"
   flutter_screenutil:
     dependency: "direct main"
     description:
@@ -852,26 +847,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "165164745e6afb5c0e3e3fcc72a012fb9e58496fb26ffb92cf22e16a821e85d0"
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.2"
+    version: "9.2.4"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: "4d91bfc23047422cbcd73ac684bc169859ee766482517c22172c86596bf1464b"
+      sha256: bf7404619d7ab5c0a1151d7c4e802edad8f33535abfbeff2f9e1fe1274e2d705
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   flutter_secure_storage_macos:
     dependency: transitive
     description:
       name: flutter_secure_storage_macos
-      sha256: "1693ab11121a5f925bbea0be725abfcfbbcf36c1e29e571f84a0c0f436147a81"
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
@@ -900,10 +895,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "7b4ca6cf3304575fe9c8ec64813c8d02ee41d2afe60bcfe0678bcb5375d596a2"
+      sha256: c200fd79c918a40c5cd50ea0877fa13f81bdaf6f0a5d3dbcc2a13e3285d6aa1b
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.10+1"
+    version: "2.0.17"
   flutter_svg_provider:
     dependency: "direct main"
     description:
@@ -926,10 +921,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: a434911f643466d78462625df76fd9eb13e57348ff43fe1f77bbe909522c67a1
+      sha256: "44c19278dd9d89292cf46e97dc0c1e52ce03275f40a97c5a348e802a924bf40e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.5.7"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -963,10 +958,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   golden_toolkit:
     dependency: "direct dev"
     description:
@@ -979,18 +974,18 @@ packages:
     dependency: transitive
     description:
       name: google_mlkit_commons
-      sha256: "27d626c66a181351a953eba5b6ff1ff123aadb891b4dab085b292118f039d6ac"
+      sha256: "7e9a6d6e66b44aa8cfe944bda9bc3346c52486dd890ca49e5bc98845cda40d7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.9.0"
   google_mlkit_face_detection:
     dependency: transitive
     description:
       name: google_mlkit_face_detection
-      sha256: "5b597061cafe4dfa70f66adddadd19381eb88bd3312b074528c62b246392304b"
+      sha256: "65988405c884fd84a4ccc8bded7b5e3e4c33362f6f4eaaa94818bdaaba7bab7d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.0"
+    version: "0.12.0"
   graphs:
     dependency: transitive
     description:
@@ -1019,42 +1014,42 @@ packages:
     dependency: transitive
     description:
       name: html
-      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
+      sha256: "1fc58edeaec4307368c60d59b7e15b9d658b57d7f3125098b6294153c75337ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.4"
+    version: "0.15.5"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
   image:
     dependency: transitive
     description:
       name: image
-      sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
+      sha256: "8346ad4b5173924b5ddddab782fc7d8a6300178c8b1dc427775405a01701c4a6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.5.2"
   image_picker:
     dependency: "direct main"
     description:
@@ -1067,26 +1062,26 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "8c5abf0dcc24fe6e8e0b4a5c0b51a5cf30cefdf6407a3213dae61edc75a70f56"
+      sha256: b62d34a506e12bb965e824b6db4fbf709ee4589cf5d3e99b45ab2287b008ee0c
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+12"
+    version: "0.8.12+20"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
-      sha256: "65d94623e15372c5c51bebbcb820848d7bcb323836e12dfdba60b5d3a8b39e50"
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   image_picker_ios:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: "6703696ad49f5c3c8356d576d7ace84d1faf459afb07accbb0fae780753ff447"
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12"
+    version: "0.8.12+2"
   image_picker_linux:
     dependency: transitive
     description:
@@ -1099,18 +1094,18 @@ packages:
     dependency: transitive
     description:
       name: image_picker_macos
-      sha256: "3f5ad1e8112a9a6111c46d0b57a7be2286a9a07fc6e1976fdf5be2bd31d4ff62"
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1+1"
+    version: "0.2.1+2"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      sha256: "9ec26d410ff46f483c5519c29c02ef0e02e13a543f882b152d4bfd2f06802f80"
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.10.1"
   image_picker_windows:
     dependency: transitive
     description:
@@ -1123,26 +1118,26 @@ packages:
     dependency: transitive
     description:
       name: image_size_getter
-      sha256: f98c4246144e9b968899d2dfde69091e22a539bb64bc9b0bea51505fbb490e57
+      sha256: "9a299e3af2ebbcfd1baf21456c3c884037ff524316c97d8e56035ea8fdf35653"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.4.0"
   injectable:
     dependency: "direct main"
     description:
       name: injectable
-      sha256: "69874ba3ec10e3a0de3f519a184442878291d928f3299d718813f24642585198"
+      sha256: "5e1556ea1d374fe44cbe846414d9bab346285d3d8a1da5877c01ad0774006068"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "2.5.0"
   injectable_generator:
     dependency: "direct dev"
     description:
       name: injectable_generator
-      sha256: "7fb573114f8bbdd169f7ae9b0bcd13f464e8170454c27be816d5a1bb39ac8086"
+      sha256: af403d76c7b18b4217335e0075e950cd0579fd7f8d7bd47ee7c85ada31680ba1
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.6.2"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -1152,26 +1147,26 @@ packages:
     dependency: "direct main"
     description:
       name: intercom_flutter
-      sha256: "4eeb6ecc55cc8d0a5b44324e2f423dab4b242041794af555cb9c1d4a3c2efa95"
+      sha256: "46ee13791cbdc79da9e0ad6a94d6d200cc5bf0a7b954d1135e34faac2a078209"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.9"
+    version: "9.2.5"
   intercom_flutter_platform_interface:
     dependency: transitive
     description:
       name: intercom_flutter_platform_interface
-      sha256: c72522eed83eb469e5a9e4b5ac7454f903de38465e0f65729ed0a9221bf32497
+      sha256: "42cd30ff7fb987567d5e58092c3625e01ddb3d1831ec269df7567f333236aa51"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.2"
   intercom_flutter_web:
     dependency: transitive
     description:
       name: intercom_flutter_web
-      sha256: b8f645ad709aecb8a025abb65adf11268ccbd46406e232ba7a506952d776b653
+      sha256: "410f624093a30972c13df8775eaf84a8dd958629aadb90e5d367518cbea79f70"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.5"
   intl:
     dependency: "direct main"
     description:
@@ -1184,26 +1179,26 @@ packages:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   jovial_misc:
     dependency: transitive
     description:
       name: jovial_misc
-      sha256: f6e64f789ee311025bb367be9c9afe9759f76dd8209070b7f38e735b5f529eb1
+      sha256: "4301011027d87b8b919cb862db84071a34448eadbb32cc8d40fe505424dfe69a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.5"
+    version: "0.9.2"
   jovial_svg:
     dependency: transitive
     description:
       name: jovial_svg
-      sha256: "893dab3d9bbb8dd03e8225d457004950b9cf828d0009fd14c185cedacb96839c"
+      sha256: "5e45b05845c8cbfec99ea32f177473ab2573d2c48479b29922c44ad329881d72"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.22"
+    version: "1.1.25"
   js:
     dependency: transitive
     description:
@@ -1224,10 +1219,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
+      sha256: c2fcb3920cf2b6ae6845954186420fca40bc0a8abcc84903b7801f17d7050d7c
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.9.0"
   jupiter_aggregator:
     dependency: "direct overridden"
     description:
@@ -1248,18 +1243,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -1272,18 +1267,26 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3-main.0"
   markdown:
     dependency: transitive
     description:
       name: markdown
-      sha256: ef2a1298144e3f985cc736b22e0ccdaf188b5b3970648f2d9dc13efd1d9df051
+      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.2"
+    version: "7.3.0"
   matcher:
     dependency: transitive
     description:
@@ -1328,26 +1331,26 @@ packages:
     dependency: "direct main"
     description:
       name: mixpanel_flutter
-      sha256: "5dc993ade5eaad51ebb6c91230971a3443ac30a3d1d24399bc3db74c5705d400"
+      sha256: c1e35c54d8cfc1c50d35d2e8cc11416295efc45bb6dcaa88aec8f82219274833
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.3"
   mobile_scanner:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: "6ac2913ad98c83f558d2c8a55bc8f511bdcf28b86639701c04b04c16da1e9ee1"
+      sha256: d234581c090526676fd8fab4ada92f35c6746e3fb4f05a399665d75a399fb760
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.1"
+    version: "5.2.3"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
+      sha256: f99d8d072e249f719a5531735d146d8cf04c580d93920b04de75bef6dfb2daf6
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.4"
+    version: "5.4.5"
   mocktail:
     dependency: transitive
     description:
@@ -1384,26 +1387,26 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   package_info_plus:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
+      sha256: "67eae327b1b0faf761964a1d2e5d323c797f3799db0e85aa232db8d9e922bc35"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "8.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      sha256: "205ec83335c2ab9107bbba3f8997f9356d72ca3c715d2f038fc773d0366b4c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   path:
     dependency: "direct main"
     description:
@@ -1416,34 +1419,34 @@ packages:
     dependency: transitive
     description:
       name: path_parsing
-      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "6f01f8e37ec30b07bc424b4deabac37cacb1bc7e2e515ad74486039918a37eb7"
+      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.10"
+    version: "2.2.15"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1480,10 +1483,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "76e4ab092c1b240d31177bb64d2b0bea43f43d0e23541ec866151b9f7b2490fa"
+      sha256: "71bbecfee799e65aff7c744761a57e817e73b738fedf62ab7afd5593da21f9f1"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.12"
+    version: "12.0.13"
   permission_handler_apple:
     dependency: transitive
     description:
@@ -1496,18 +1499,18 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: af26edbbb1f2674af65a8f4b56e1a6f526156bc273d0e65dd8075fab51c78851
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+2"
+    version: "0.1.3+5"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: fe0ffe274d665be8e34f9c59705441a7d248edebbe5d9e3ec2665f88b79358ea
+      sha256: e9c8eadee926c4532d0305dff94b85bf961f16759c3af791486613152af4b4f9
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.2.3"
   permission_handler_windows:
     dependency: transitive
     description:
@@ -1572,6 +1575,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: a0117dc2167805aa9125b82eee515cc891819bac2f538c83646d355b16f58b9a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.1"
   process:
     dependency: transitive
     description:
@@ -1600,18 +1611,18 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   qr:
     dependency: transitive
     description:
@@ -1648,34 +1659,34 @@ packages:
     dependency: "direct main"
     description:
       name: retrofit
-      sha256: "3c9885ef3dbc5dc4b3fb0a40c972ab52e4dad04d52dac9bba24dfa76cf100451"
+      sha256: c6cc9ad3374e6d07008343140a67afffaaa34cdf6bf08d4847d91417a99dcf45
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.1"
+    version: "4.4.2"
   retrofit_generator:
     dependency: "direct dev"
     description:
       name: retrofit_generator
-      sha256: "40f166d6e07fc3c8f77700093767fd0c1b4742d27fe049ecb15cea1245284bd8"
+      sha256: "8dfc406cdfa171f33cbd21bf5bd8b6763548cc217de19cdeaa07a76727fac4ca"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.6"
+    version: "8.2.1"
   rive:
     dependency: "direct main"
     description:
       name: rive
-      sha256: "468f0880d49c513e09fdfba26e4abd9d50433c2cf398210b62948d8de3837dd5"
+      sha256: "2551a44fa766a7ed3f52aa2b94feda6d18d00edc25dee5f66e72e9b365bb6d6c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.15"
+    version: "0.13.20"
   rive_common:
     dependency: transitive
     description:
       name: rive_common
-      sha256: a3e5786f8d85c89977062b9ceeb3b72a7c28f81e32fb68497744042ce20bee2f
+      sha256: "2ba42f80d37a4efd0696fb715787c4785f8a13361e8aea9227c50f1e78cf763a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.15"
   rxdart:
     dependency: "direct main"
     description:
@@ -1712,18 +1723,18 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "1af8308298977259430d118ab25be8e1dda626cdefa1e6ce869073d530d39271"
+      sha256: "41a3c8e61d5194f5e12adf469fc430d7fa76a373fde6b11280f7df05c24e19e2"
       url: "https://pub.dev"
     source: hosted
-    version: "8.8.0"
+    version: "8.13.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "18fe4d125c2d529bd6127200f0d2895768266a8c60b4fb50b2086fd97e1a4ab2"
+      sha256: "86ba98250bfc55cf3a9908afa46a851a46706e8338413d062daa5705ce016d05"
       url: "https://pub.dev"
     source: hosted
-    version: "8.8.0"
+    version: "8.13.0"
   share:
     dependency: "direct main"
     description:
@@ -1736,26 +1747,26 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
+      sha256: "846849e3e9b68f3ef4b60c60cf4b3e02e9321bc7f4d8c4692cf87ffa82fc8a3a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.5.2"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "480ba4345773f56acda9abf5f50bd966f581dac5d514e5fc4a18c62976bbba7e"
+      sha256: ea86be7b7114f9e94fddfbb52649e59a03d6627ccd2387ebddcd6624719e9f16
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.5"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: c4b35f6cb8f63c147312c054ce7c2254c8066745125264f0c88739c417fc9d9f
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.5.4"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -1792,10 +1803,10 @@ packages:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -1808,10 +1819,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -1824,7 +1835,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   sliver_tools:
     dependency: "direct main"
     description:
@@ -1867,10 +1878,10 @@ packages:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
+      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.4"
+    version: "1.3.5"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1883,10 +1894,10 @@ packages:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.12"
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -1907,58 +1918,82 @@ packages:
     dependency: transitive
     description:
       name: sqflite
-      sha256: a43e5a27235518c03ca238e7b4732cf35eabe863a369ceba6cbefa537a66f16d
+      sha256: "2d7299468485dca85efeeadf5d38986909c5eb0cd71fd3db2c2f000e6c9454bb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3+1"
+    version: "2.4.1"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "78f489aab276260cdd26676d2169446c7ecd3484bbd5fead4ca14f3ed4dd9ee3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
+      sha256: "761b9740ecbd4d3e66b8916d784e581861fd3c3553eda85e167bc49fdb68f709"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.4+6"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "22adfd9a2c7d634041e96d6241e6e1c8138ca6817018afc5d443fef91dcefa9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1+1"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: cb7f4e9dc1b52b1fa350f7b3d41c662e75fc3d399555fa4e5efcf267e9a4fbb5
+      sha256: decd58236d7c59e01ae81b34ebd158e6a1b61e0ae5397fc428736eb91ab82808
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.3"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
-      sha256: "62bbb4073edbcdf53f40c80775f33eea01d301b7b81417e5b3fb7395416258c1"
+      sha256: "57fafacd815c981735406215966ff7caaa8eab984b094f52e692accefcbd9233"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.24"
+    version: "0.5.30"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "7b20045d1ccfb7bc1df7e8f9fee5ae58673fce6ff62cefbb0e0fd7214e90e5a0"
+      sha256: "27dd0a9f0c02e22ac0eb42a23df9ea079ce69b52bb4a3b478d64e0ef34a263ee"
       url: "https://pub.dev"
     source: hosted
-    version: "0.34.1"
+    version: "0.41.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stellar_flutter_sdk:
     dependency: "direct main"
     description:
       name: stellar_flutter_sdk
-      sha256: bb3194fca066590942c8395ff79d08c6b32d0cf3df5b4ebd32a9dd72340a0d9e
+      sha256: dac5c9d4874ec8bb93541328718870a683dfb74d5f31c411f39b85e14cd70e79
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.6"
+    version: "1.9.2"
   storybook_flutter:
     dependency: "direct main"
     description:
@@ -1979,18 +2014,18 @@ packages:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   sync_http:
     dependency: transitive
     description:
@@ -2003,10 +2038,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
+      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0+1"
+    version: "3.3.0+3"
   term_glyph:
     dependency: transitive
     description:
@@ -2019,50 +2054,50 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.7"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   time:
     dependency: transitive
     description:
       name: time
-      sha256: ad8e018a6c9db36cb917a031853a1aae49467a93e0d464683e029537d848c221
+      sha256: "370572cf5d1e58adcb3e354c47515da3f7469dac3a95b447117e728e7be6f461"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   timing:
     dependency: transitive
     description:
       name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   toml:
     dependency: transitive
     description:
       name: toml
-      sha256: "9968de24e45b632bf1a654fe1ac7b6fe5261c349243df83fd262397799c45a2d"
+      sha256: d968d149c8bd06dc14e09ea3a140f90a3f2ba71949e7a91df4a46f3107400e71
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.0"
+    version: "0.16.0"
   tuple:
     dependency: transitive
     description:
@@ -2075,10 +2110,10 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   uni_links:
     dependency: "direct main"
     description:
@@ -2123,42 +2158,42 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "21b704ce5fa560ea9f3b525b43601c678728ba46725bab9b01187b4831377ed3"
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.3.1"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: f0c73347dfcfa5b3db8bc06e1502668265d39c08f310c29bff4e28eea9699f79
+      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.9"
+    version: "6.3.14"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
+      sha256: "16a513b6c12bb419304e72ea0ae2ab4fed569920d1c7cb850263fe3acc824626"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: e2b9622b4007f97f504cd64c0128309dfb978ae66adbe944125ed9e1750f06af
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -2171,50 +2206,50 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
+      sha256: "3ba963161bd0fe395917ba881d320b9c4f6dd3c4a233da62ab18a5025c85f1e9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.0"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.4"
   uuid:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: f33d6bb662f0e4f79dcd7ada2e6170f3b3a2530c28fc41f49a411ddedd576a77
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.5.1"
   vector_graphics:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "32c3c684e02f9bc0afb0ae0aa653337a2fe022e8ab064bcd7ffda27a74e288e3"
+      sha256: "44cc7104ff32563122a929e4620cf3efd584194eec6d1d913eb5ba593dbcf6de"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11+1"
+    version: "1.1.18"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: c86987475f162fadff579e7320c7ddda04cd2fdeffbe1129227a85d9ac9e03da
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11+1"
+    version: "1.1.13"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "12faff3f73b1741a36ca7e31b292ddeb629af819ca9efe9953b70bd63fc8cd81"
+      sha256: "1b4b9e706a10294258727674a340ae0d6e64a7231980f9f9a3d12e4b42407aad"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11+1"
+    version: "1.1.16"
   vector_math:
     dependency: transitive
     description:
@@ -2227,18 +2262,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web:
     dependency: transitive
     description:
@@ -2259,18 +2294,18 @@ packages:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
+      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.4"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -2283,18 +2318,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "68d1e89a91ed61ad9c370f9f8b6effed9ae5e0ede22a270bdfa6daf79fc2290a"
+      sha256: daf97c9d80197ed7b619040e86c8ab9a9dad285e7671ee7390f9180cc828a51e
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.4"
+    version: "5.10.1"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:
@@ -2307,10 +2342,10 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"

--- a/packages/espressocash_app/pubspec.yaml
+++ b/packages/espressocash_app/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   bloc_concurrency: ^0.2.3
   borsh_annotation: ^0.3.1+5
   cached_network_image: ^3.3.1
-  collection: ^1.18.0
+  collection: # Implied by integration_test.
   country_flags: ^3.0.0
   crypto: ^3.0.2
   dart_jsonwebtoken: ^2.14.0

--- a/packages/espressocash_app/test/migrations_test.dart
+++ b/packages/espressocash_app/test/migrations_test.dart
@@ -3,6 +3,7 @@ import 'package:drift_dev/api/migrations.dart';
 import 'package:espressocash_app/data/db/db.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+// Run `make flutter_generate_test_schemas` to generate the file.
 import 'generated/schema.dart';
 
 void main() {

--- a/packages/jsonrpc_client/lib/src/client_generator.dart
+++ b/packages/jsonrpc_client/lib/src/client_generator.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use, drop deprecated usages until we raise SDK constraint lower-bound.
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';

--- a/packages/jsonrpc_client/pubspec.yaml
+++ b/packages/jsonrpc_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=2.14.3 <3.0.0"
+  sdk: ">=2.14.3 <4.0.0"
 
 dependencies:
   analyzer: ">=4.4.0 <6.0.0"

--- a/packages/jsonrpc_client/pubspec.yaml
+++ b/packages/jsonrpc_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=4.4.0 <6.0.0"
+  analyzer: ">=5.4.0 <8.0.0"
   build: ^2.1.1
   http: ^1.1.0
   solana:

--- a/packages/jsonrpc_client/pubspec.yaml
+++ b/packages/jsonrpc_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=2.14.3 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   analyzer: ">=4.4.0 <6.0.0"

--- a/packages/jsonrpc_client/pubspec.yaml
+++ b/packages/jsonrpc_client/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   http: ^1.1.0
   solana:
     path: ../solana
-  source_gen: ^1.1.1
+  source_gen: ">=1.4.0 <3.0.0"
 
 dev_dependencies:
   mews_pedantic: ^0.27.0

--- a/packages/jsonrpc_client/pubspec.yaml
+++ b/packages/jsonrpc_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   analyzer: ">=5.4.0 <8.0.0"

--- a/packages/jsonrpc_client/pubspec.yaml
+++ b/packages/jsonrpc_client/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
   source_gen: ^1.1.1
 
 dev_dependencies:
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
   test: ^1.16.0

--- a/packages/jupiter_aggregator/lib/src/client.g.dart
+++ b/packages/jupiter_aggregator/lib/src/client.g.dart
@@ -6,16 +6,10 @@ part of 'client.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
 class _JupiterAggregatorClient implements JupiterAggregatorClient {
-  _JupiterAggregatorClient(
-    this._dio, {
-    this.baseUrl,
-    this.errorLogger,
-  }) {
-    baseUrl ??= 'https://quote-api.jup.ag/v6';
-  }
+  _JupiterAggregatorClient(this._dio, {this.baseUrl, this.errorLogger});
 
   final Dio _dio;
 
@@ -30,22 +24,16 @@ class _JupiterAggregatorClient implements JupiterAggregatorClient {
     queryParameters.addAll(quoteRequestDto.toJson());
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _options = _setStreamType<QuoteResponseDto>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/quote',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        )));
+    final _options = _setStreamType<QuoteResponseDto>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/quote',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
     late QuoteResponseDto _value;
     try {
@@ -59,28 +47,23 @@ class _JupiterAggregatorClient implements JupiterAggregatorClient {
 
   @override
   Future<JupiterSwapResponseDto> getSwapTransactions(
-      JupiterSwapRequestDto swapRequestDto) async {
+    JupiterSwapRequestDto swapRequestDto,
+  ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(swapRequestDto.toJson());
-    final _options = _setStreamType<JupiterSwapResponseDto>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/swap',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        )));
+    final _options = _setStreamType<JupiterSwapResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/swap',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
     late JupiterSwapResponseDto _value;
     try {
@@ -105,10 +88,7 @@ class _JupiterAggregatorClient implements JupiterAggregatorClient {
     return requestOptions;
   }
 
-  String _combineBaseUrls(
-    String dioBaseUrl,
-    String? baseUrl,
-  ) {
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
     if (baseUrl == null || baseUrl.trim().isEmpty) {
       return dioBaseUrl;
     }
@@ -123,16 +103,10 @@ class _JupiterAggregatorClient implements JupiterAggregatorClient {
   }
 }
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
 class _JupiterPriceClient implements JupiterPriceClient {
-  _JupiterPriceClient(
-    this._dio, {
-    this.baseUrl,
-    this.errorLogger,
-  }) {
-    baseUrl ??= 'https://api.jup.ag';
-  }
+  _JupiterPriceClient(this._dio, {this.baseUrl, this.errorLogger});
 
   final Dio _dio;
 
@@ -147,22 +121,16 @@ class _JupiterPriceClient implements JupiterPriceClient {
     queryParameters.addAll(priceRequestDto.toJson());
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _options = _setStreamType<PriceResponseDto>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/price/v2',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        )));
+    final _options = _setStreamType<PriceResponseDto>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/price/v2',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
     late PriceResponseDto _value;
     try {
@@ -187,10 +155,7 @@ class _JupiterPriceClient implements JupiterPriceClient {
     return requestOptions;
   }
 
-  String _combineBaseUrls(
-    String dioBaseUrl,
-    String? baseUrl,
-  ) {
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
     if (baseUrl == null || baseUrl.trim().isEmpty) {
       return dioBaseUrl;
     }

--- a/packages/jupiter_aggregator/pubspec.yaml
+++ b/packages/jupiter_aggregator/pubspec.yaml
@@ -16,5 +16,5 @@ dev_dependencies:
   freezed: ^2.2.0
   json_serializable: ^6.5.2
   mews_pedantic: ^0.27.0
-  retrofit_generator: ^8.0.6
+  retrofit_generator: ">=8.0.6 <10.0.0"
   test: ^1.24.0

--- a/packages/jupiter_aggregator/pubspec.yaml
+++ b/packages/jupiter_aggregator/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.5
 publish_to: "none"
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   dio: ^5.4.0

--- a/packages/jupiter_aggregator/pubspec.yaml
+++ b/packages/jupiter_aggregator/pubspec.yaml
@@ -15,6 +15,6 @@ dev_dependencies:
   build_runner: ^2.3.2
   freezed: ^2.2.0
   json_serializable: ^6.5.2
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
   retrofit_generator: ^8.0.6
   test: ^1.24.0

--- a/packages/solana/lib/src/encoder/address_lookup_table/address_lookup_table.freezed.dart
+++ b/packages/solana/lib/src/encoder/address_lookup_table/address_lookup_table.freezed.dart
@@ -12,7 +12,7 @@ part of 'address_lookup_table.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$AddressLookupTableState {
@@ -22,7 +22,9 @@ mixin _$AddressLookupTableState {
   Ed25519HDPublicKey? get authority => throw _privateConstructorUsedError;
   List<Ed25519HDPublicKey> get addresses => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AddressLookupTableState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $AddressLookupTableStateCopyWith<AddressLookupTableState> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -52,6 +54,8 @@ class _$AddressLookupTableStateCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of AddressLookupTableState
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -113,6 +117,8 @@ class __$$AddressLookupTableStateImplCopyWithImpl<$Res>
       $Res Function(_$AddressLookupTableStateImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AddressLookupTableState
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -207,7 +213,9 @@ class _$AddressLookupTableStateImpl implements _AddressLookupTableState {
       authority,
       const DeepCollectionEquality().hash(_addresses));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AddressLookupTableState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AddressLookupTableStateImplCopyWith<_$AddressLookupTableStateImpl>
@@ -234,8 +242,11 @@ abstract class _AddressLookupTableState implements AddressLookupTableState {
   Ed25519HDPublicKey? get authority;
   @override
   List<Ed25519HDPublicKey> get addresses;
+
+  /// Create a copy of AddressLookupTableState
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AddressLookupTableStateImplCopyWith<_$AddressLookupTableStateImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/encoder/compiled_instruction.freezed.dart
+++ b/packages/solana/lib/src/encoder/compiled_instruction.freezed.dart
@@ -12,7 +12,7 @@ part of 'compiled_instruction.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$CompiledInstruction {
@@ -20,7 +20,9 @@ mixin _$CompiledInstruction {
   List<int> get accountKeyIndexes => throw _privateConstructorUsedError;
   ByteArray get data => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CompiledInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CompiledInstructionCopyWith<CompiledInstruction> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -44,6 +46,8 @@ class _$CompiledInstructionCopyWithImpl<$Res, $Val extends CompiledInstruction>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of CompiledInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -87,6 +91,8 @@ class __$$CompiledInstructionImplCopyWithImpl<$Res>
       $Res Function(_$CompiledInstructionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of CompiledInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -159,7 +165,9 @@ class _$CompiledInstructionImpl extends _CompiledInstruction {
       const DeepCollectionEquality().hash(_accountKeyIndexes),
       const DeepCollectionEquality().hash(data));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CompiledInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CompiledInstructionImplCopyWith<_$CompiledInstructionImpl> get copyWith =>
@@ -180,8 +188,11 @@ abstract class _CompiledInstruction extends CompiledInstruction {
   List<int> get accountKeyIndexes;
   @override
   ByteArray get data;
+
+  /// Create a copy of CompiledInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CompiledInstructionImplCopyWith<_$CompiledInstructionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/encoder/compiled_message.freezed.dart
+++ b/packages/solana/lib/src/encoder/compiled_message.freezed.dart
@@ -12,7 +12,7 @@ part of 'compiled_message.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$CompiledMessage {
@@ -91,7 +91,9 @@ mixin _$CompiledMessage {
   }) =>
       throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CompiledMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CompiledMessageCopyWith<CompiledMessage> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -121,6 +123,8 @@ class _$CompiledMessageCopyWithImpl<$Res, $Val extends CompiledMessage>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of CompiledMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -149,6 +153,8 @@ class _$CompiledMessageCopyWithImpl<$Res, $Val extends CompiledMessage>
     ) as $Val);
   }
 
+  /// Create a copy of CompiledMessage
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $MessageHeaderCopyWith<$Res> get header {
@@ -185,6 +191,8 @@ class __$$CompiledMessageLegacyImplCopyWithImpl<$Res>
       $Res Function(_$CompiledMessageLegacyImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of CompiledMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -273,7 +281,9 @@ class _$CompiledMessageLegacyImpl extends CompiledMessageLegacy {
       recentBlockhash,
       const DeepCollectionEquality().hash(_instructions));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CompiledMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CompiledMessageLegacyImplCopyWith<_$CompiledMessageLegacyImpl>
@@ -390,8 +400,11 @@ abstract class CompiledMessageLegacy extends CompiledMessage {
   String get recentBlockhash;
   @override
   List<CompiledInstruction> get instructions;
+
+  /// Create a copy of CompiledMessage
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CompiledMessageLegacyImplCopyWith<_$CompiledMessageLegacyImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -423,6 +436,8 @@ class __$$CompiledMessageV0ImplCopyWithImpl<$Res>
       $Res Function(_$CompiledMessageV0Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of CompiledMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -530,7 +545,9 @@ class _$CompiledMessageV0Impl extends CompiledMessageV0 {
       const DeepCollectionEquality().hash(_instructions),
       const DeepCollectionEquality().hash(_addressTableLookups));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CompiledMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CompiledMessageV0ImplCopyWith<_$CompiledMessageV0Impl> get copyWith =>
@@ -652,8 +669,11 @@ abstract class CompiledMessageV0 extends CompiledMessage {
   @override
   List<CompiledInstruction> get instructions;
   List<MessageAddressTableLookup> get addressTableLookups;
+
+  /// Create a copy of CompiledMessage
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CompiledMessageV0ImplCopyWith<_$CompiledMessageV0Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/encoder/message/compiled_key_meta.freezed.dart
+++ b/packages/solana/lib/src/encoder/message/compiled_key_meta.freezed.dart
@@ -12,7 +12,7 @@ part of 'compiled_key_meta.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$CompiledKeyMeta {
@@ -20,7 +20,9 @@ mixin _$CompiledKeyMeta {
   bool get isWritable => throw _privateConstructorUsedError;
   bool get isInvoked => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CompiledKeyMeta
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CompiledKeyMetaCopyWith<CompiledKeyMeta> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -44,6 +46,8 @@ class _$CompiledKeyMetaCopyWithImpl<$Res, $Val extends CompiledKeyMeta>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of CompiledKeyMeta
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -87,6 +91,8 @@ class __$$CompiledKeyMetaImplCopyWithImpl<$Res>
       _$CompiledKeyMetaImpl _value, $Res Function(_$CompiledKeyMetaImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of CompiledKeyMeta
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -147,7 +153,9 @@ class _$CompiledKeyMetaImpl implements _CompiledKeyMeta {
   @override
   int get hashCode => Object.hash(runtimeType, isSigner, isWritable, isInvoked);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CompiledKeyMeta
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CompiledKeyMetaImplCopyWith<_$CompiledKeyMetaImpl> get copyWith =>
@@ -167,8 +175,11 @@ abstract class _CompiledKeyMeta implements CompiledKeyMeta {
   bool get isWritable;
   @override
   bool get isInvoked;
+
+  /// Create a copy of CompiledKeyMeta
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CompiledKeyMetaImplCopyWith<_$CompiledKeyMetaImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/encoder/message/loaded_addresses.freezed.dart
+++ b/packages/solana/lib/src/encoder/message/loaded_addresses.freezed.dart
@@ -12,14 +12,16 @@ part of 'loaded_addresses.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$LoadedAddresses {
   List<Ed25519HDPublicKey> get writable => throw _privateConstructorUsedError;
   List<Ed25519HDPublicKey> get readonly => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LoadedAddresses
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $LoadedAddressesCopyWith<LoadedAddresses> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -44,6 +46,8 @@ class _$LoadedAddressesCopyWithImpl<$Res, $Val extends LoadedAddresses>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of LoadedAddresses
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -83,6 +87,8 @@ class __$$LoadedAddressesImplCopyWithImpl<$Res>
       _$LoadedAddressesImpl _value, $Res Function(_$LoadedAddressesImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LoadedAddresses
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -147,7 +153,9 @@ class _$LoadedAddressesImpl implements _LoadedAddresses {
       const DeepCollectionEquality().hash(_writable),
       const DeepCollectionEquality().hash(_readonly));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LoadedAddresses
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedAddressesImplCopyWith<_$LoadedAddressesImpl> get copyWith =>
@@ -165,8 +173,11 @@ abstract class _LoadedAddresses implements LoadedAddresses {
   List<Ed25519HDPublicKey> get writable;
   @override
   List<Ed25519HDPublicKey> get readonly;
+
+  /// Create a copy of LoadedAddresses
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LoadedAddressesImplCopyWith<_$LoadedAddressesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/encoder/message/message.freezed.dart
+++ b/packages/solana/lib/src/encoder/message/message.freezed.dart
@@ -12,13 +12,15 @@ part of 'message.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$Message {
   List<Instruction> get instructions => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Message
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MessageCopyWith<Message> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -40,6 +42,8 @@ class _$MessageCopyWithImpl<$Res, $Val extends Message>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Message
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -72,6 +76,8 @@ class __$$MessageImplCopyWithImpl<$Res>
       _$MessageImpl _value, $Res Function(_$MessageImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Message
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -119,7 +125,9 @@ class _$MessageImpl extends _Message {
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(_instructions));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Message
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MessageImplCopyWith<_$MessageImpl> get copyWith =>
@@ -133,8 +141,11 @@ abstract class _Message extends Message {
 
   @override
   List<Instruction> get instructions;
+
+  /// Create a copy of Message
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MessageImplCopyWith<_$MessageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/encoder/message_address_table_lookup.freezed.dart
+++ b/packages/solana/lib/src/encoder/message_address_table_lookup.freezed.dart
@@ -12,7 +12,7 @@ part of 'message_address_table_lookup.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$MessageAddressTableLookup {
@@ -20,7 +20,9 @@ mixin _$MessageAddressTableLookup {
   List<int> get writableIndexes => throw _privateConstructorUsedError;
   List<int> get readonlyIndexes => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MessageAddressTableLookup
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MessageAddressTableLookupCopyWith<MessageAddressTableLookup> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -48,6 +50,8 @@ class _$MessageAddressTableLookupCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MessageAddressTableLookup
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -97,6 +101,8 @@ class __$$MessageAddressTableLookupImplCopyWithImpl<$Res>
       $Res Function(_$MessageAddressTableLookupImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MessageAddressTableLookup
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -174,7 +180,9 @@ class _$MessageAddressTableLookupImpl implements _MessageAddressTableLookup {
       const DeepCollectionEquality().hash(_writableIndexes),
       const DeepCollectionEquality().hash(_readonlyIndexes));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MessageAddressTableLookup
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MessageAddressTableLookupImplCopyWith<_$MessageAddressTableLookupImpl>
@@ -195,8 +203,11 @@ abstract class _MessageAddressTableLookup implements MessageAddressTableLookup {
   List<int> get writableIndexes;
   @override
   List<int> get readonlyIndexes;
+
+  /// Create a copy of MessageAddressTableLookup
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MessageAddressTableLookupImplCopyWith<_$MessageAddressTableLookupImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/encoder/message_header.freezed.dart
+++ b/packages/solana/lib/src/encoder/message_header.freezed.dart
@@ -12,7 +12,7 @@ part of 'message_header.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$MessageHeader {
@@ -20,7 +20,9 @@ mixin _$MessageHeader {
   int get numReadonlySignedAccounts => throw _privateConstructorUsedError;
   int get numReadonlyUnsignedAccounts => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MessageHeader
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MessageHeaderCopyWith<MessageHeader> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -47,6 +49,8 @@ class _$MessageHeaderCopyWithImpl<$Res, $Val extends MessageHeader>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MessageHeader
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -93,6 +97,8 @@ class __$$MessageHeaderImplCopyWithImpl<$Res>
       _$MessageHeaderImpl _value, $Res Function(_$MessageHeaderImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MessageHeader
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -158,7 +164,9 @@ class _$MessageHeaderImpl extends _MessageHeader {
   int get hashCode => Object.hash(runtimeType, numRequiredSignatures,
       numReadonlySignedAccounts, numReadonlyUnsignedAccounts);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MessageHeader
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MessageHeaderImplCopyWith<_$MessageHeaderImpl> get copyWith =>
@@ -178,8 +186,11 @@ abstract class _MessageHeader extends MessageHeader {
   int get numReadonlySignedAccounts;
   @override
   int get numReadonlyUnsignedAccounts;
+
+  /// Create a copy of MessageHeader
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MessageHeaderImplCopyWith<_$MessageHeaderImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/encoder/signed_tx.freezed.dart
+++ b/packages/solana/lib/src/encoder/signed_tx.freezed.dart
@@ -12,14 +12,16 @@ part of 'signed_tx.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$SignedTx {
   List<Signature> get signatures => throw _privateConstructorUsedError;
   CompiledMessage get compiledMessage => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SignedTx
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SignedTxCopyWith<SignedTx> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -44,6 +46,8 @@ class _$SignedTxCopyWithImpl<$Res, $Val extends SignedTx>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SignedTx
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -62,6 +66,8 @@ class _$SignedTxCopyWithImpl<$Res, $Val extends SignedTx>
     ) as $Val);
   }
 
+  /// Create a copy of SignedTx
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $CompiledMessageCopyWith<$Res> get compiledMessage {
@@ -93,6 +99,8 @@ class __$$SignedTxImplCopyWithImpl<$Res>
       _$SignedTxImpl _value, $Res Function(_$SignedTxImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SignedTx
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -153,7 +161,9 @@ class _$SignedTxImpl extends _SignedTx {
   int get hashCode => Object.hash(runtimeType,
       const DeepCollectionEquality().hash(_signatures), compiledMessage);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SignedTx
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SignedTxImplCopyWith<_$SignedTxImpl> get copyWith =>
@@ -170,8 +180,11 @@ abstract class _SignedTx extends SignedTx {
   List<Signature> get signatures;
   @override
   CompiledMessage get compiledMessage;
+
+  /// Create a copy of SignedTx
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SignedTxImplCopyWith<_$SignedTxImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/exceptions/json_rpc_exception.g.dart
+++ b/packages/solana/lib/src/exceptions/json_rpc_exception.g.dart
@@ -9,7 +9,7 @@ part of 'json_rpc_exception.dart';
 JsonRpcException _$JsonRpcExceptionFromJson(Map<String, dynamic> json) =>
     JsonRpcException(
       json['message'] as String,
-      json['code'] as int,
+      (json['code'] as num).toInt(),
       json['data'],
     );
 

--- a/packages/solana/lib/src/metaplex/properties.freezed.dart
+++ b/packages/solana/lib/src/metaplex/properties.freezed.dart
@@ -12,7 +12,7 @@ part of 'properties.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 Properties _$PropertiesFromJson(Map<String, dynamic> json) {
   switch (json['category']) {
@@ -96,6 +96,8 @@ mixin _$Properties {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this Properties to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
 
@@ -115,6 +117,9 @@ class _$PropertiesCopyWithImpl<$Res, $Val extends Properties>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -131,6 +136,9 @@ class __$$UnknownImplCopyWithImpl<$Res>
   __$$UnknownImplCopyWithImpl(
       _$UnknownImpl _value, $Res Function(_$UnknownImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -155,7 +163,7 @@ class _$UnknownImpl implements Unknown {
         (other.runtimeType == runtimeType && other is _$UnknownImpl);
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => runtimeType.hashCode;
 
@@ -276,6 +284,8 @@ class __$$VideoImplCopyWithImpl<$Res>
       _$VideoImpl _value, $Res Function(_$VideoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -324,12 +334,14 @@ class _$VideoImpl implements Video {
             const DeepCollectionEquality().equals(other._files, _files));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_files));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$VideoImplCopyWith<_$VideoImpl> get copyWith =>
@@ -435,7 +447,10 @@ abstract class Video implements Properties {
   factory Video.fromJson(Map<String, dynamic> json) = _$VideoImpl.fromJson;
 
   List<File> get files;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$VideoImplCopyWith<_$VideoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -457,6 +472,8 @@ class __$$ImageImplCopyWithImpl<$Res>
       _$ImageImpl _value, $Res Function(_$ImageImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -505,12 +522,14 @@ class _$ImageImpl implements Image {
             const DeepCollectionEquality().equals(other._files, _files));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_files));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ImageImplCopyWith<_$ImageImpl> get copyWith =>
@@ -616,7 +635,10 @@ abstract class Image implements Properties {
   factory Image.fromJson(Map<String, dynamic> json) = _$ImageImpl.fromJson;
 
   List<File> get files;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ImageImplCopyWith<_$ImageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -638,6 +660,8 @@ class __$$Model3DImplCopyWithImpl<$Res>
       _$Model3DImpl _value, $Res Function(_$Model3DImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -686,12 +710,14 @@ class _$Model3DImpl implements Model3D {
             const DeepCollectionEquality().equals(other._files, _files));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_files));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$Model3DImplCopyWith<_$Model3DImpl> get copyWith =>
@@ -797,7 +823,10 @@ abstract class Model3D implements Properties {
   factory Model3D.fromJson(Map<String, dynamic> json) = _$Model3DImpl.fromJson;
 
   List<File> get files;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$Model3DImplCopyWith<_$Model3DImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -819,6 +848,8 @@ class __$$AudioImplCopyWithImpl<$Res>
       _$AudioImpl _value, $Res Function(_$AudioImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -867,12 +898,14 @@ class _$AudioImpl implements Audio {
             const DeepCollectionEquality().equals(other._files, _files));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_files));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AudioImplCopyWith<_$AudioImpl> get copyWith =>
@@ -978,7 +1011,10 @@ abstract class Audio implements Properties {
   factory Audio.fromJson(Map<String, dynamic> json) = _$AudioImpl.fromJson;
 
   List<File> get files;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AudioImplCopyWith<_$AudioImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -999,6 +1035,8 @@ class __$$HtmlImplCopyWithImpl<$Res>
   __$$HtmlImplCopyWithImpl(_$HtmlImpl _value, $Res Function(_$HtmlImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1047,12 +1085,14 @@ class _$HtmlImpl implements Html {
             const DeepCollectionEquality().equals(other._files, _files));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_files));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$HtmlImplCopyWith<_$HtmlImpl> get copyWith =>
@@ -1158,7 +1198,10 @@ abstract class Html implements Properties {
   factory Html.fromJson(Map<String, dynamic> json) = _$HtmlImpl.fromJson;
 
   List<File> get files;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Properties
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$HtmlImplCopyWith<_$HtmlImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/programs/token_program/mint.freezed.dart
+++ b/packages/solana/lib/src/programs/token_program/mint.freezed.dart
@@ -12,7 +12,7 @@ part of 'mint.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$Mint {
@@ -38,7 +38,9 @@ mixin _$Mint {
   /// Optional authority to freeze token accounts.
   Ed25519HDPublicKey? get freezeAuthority => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Mint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MintCopyWith<Mint> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -66,6 +68,8 @@ class _$MintCopyWithImpl<$Res, $Val extends Mint>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Mint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -128,6 +132,8 @@ class __$$MintImplCopyWithImpl<$Res>
   __$$MintImplCopyWithImpl(_$MintImpl _value, $Res Function(_$MintImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Mint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -232,7 +238,9 @@ class _$MintImpl implements _Mint {
   int get hashCode => Object.hash(runtimeType, address, supply, decimals,
       mintAuthority, isInitialized, freezeAuthority);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Mint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MintImplCopyWith<_$MintImpl> get copyWith =>
@@ -248,36 +256,38 @@ abstract class _Mint implements Mint {
       required final bool isInitialized,
       final Ed25519HDPublicKey? freezeAuthority}) = _$MintImpl;
 
-  @override
-
   /// Address of the mint
-  Ed25519HDPublicKey get address;
   @override
+  Ed25519HDPublicKey get address;
 
   /// Total supply of tokens.
-  BigInt get supply;
   @override
+  BigInt get supply;
 
   /// Number of base 10 digits to the right of the decimal place.
-  int get decimals;
   @override
+  int get decimals;
 
   /// Optional authority used to mint new tokens.
   ///
   /// The mint authority may only be provided during mint creation. If no mint
   /// authority is present then the mint has a fixed supply and no further
   /// tokens may be minted.
-  Ed25519HDPublicKey? get mintAuthority;
   @override
+  Ed25519HDPublicKey? get mintAuthority;
 
   /// Is this mint initialized
-  bool get isInitialized;
   @override
+  bool get isInitialized;
 
   /// Optional authority to freeze token accounts.
-  Ed25519HDPublicKey? get freezeAuthority;
   @override
-  @JsonKey(ignore: true)
+  Ed25519HDPublicKey? get freezeAuthority;
+
+  /// Create a copy of Mint
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MintImplCopyWith<_$MintImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/rpc/client.g.dart
+++ b/packages/solana/lib/src/rpc/client.g.dart
@@ -7,22 +7,14 @@ part of 'client.dart';
 // **************************************************************************
 
 Map<String, dynamic> _$GetAccountInfoConfigToJson(
-    GetAccountInfoConfig instance) {
-  final val = <String, dynamic>{
-    'commitment': _$CommitmentEnumMap[instance.commitment]!,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('encoding', _$EncodingEnumMap[instance.encoding]);
-  writeNotNull('dataSlice', instance.dataSlice?.toJson());
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetAccountInfoConfig instance) =>
+    <String, dynamic>{
+      'commitment': _$CommitmentEnumMap[instance.commitment]!,
+      if (_$EncodingEnumMap[instance.encoding] case final value?)
+        'encoding': value,
+      if (instance.dataSlice?.toJson() case final value?) 'dataSlice': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 const _$CommitmentEnumMap = {
   Commitment.processed: 'processed',
@@ -37,38 +29,26 @@ const _$EncodingEnumMap = {
   Encoding.json: 'json',
 };
 
-Map<String, dynamic> _$GetBalanceConfigToJson(GetBalanceConfig instance) {
-  final val = <String, dynamic>{};
+Map<String, dynamic> _$GetBalanceConfigToJson(GetBalanceConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
-
-Map<String, dynamic> _$GetBlockConfigToJson(GetBlockConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('encoding', _$EncodingEnumMap[instance.encoding]);
-  writeNotNull('transactionDetails',
-      _$TransactionDetailLevelEnumMap[instance.transactionDetails]);
-  writeNotNull('rewards', instance.rewards);
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('maxSupportedTransactionVersion',
-      instance.maxSupportedTransactionVersion);
-  return val;
-}
+Map<String, dynamic> _$GetBlockConfigToJson(GetBlockConfig instance) =>
+    <String, dynamic>{
+      if (_$EncodingEnumMap[instance.encoding] case final value?)
+        'encoding': value,
+      if (_$TransactionDetailLevelEnumMap[instance.transactionDetails]
+          case final value?)
+        'transactionDetails': value,
+      if (instance.rewards case final value?) 'rewards': value,
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.maxSupportedTransactionVersion case final value?)
+        'maxSupportedTransactionVersion': value,
+    };
 
 const _$TransactionDetailLevelEnumMap = {
   TransactionDetailLevel.none: 'none',
@@ -77,136 +57,74 @@ const _$TransactionDetailLevelEnumMap = {
 };
 
 Map<String, dynamic> _$GetBlockHeightConfigToJson(
-    GetBlockHeightConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetBlockHeightConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetBlockProductionConfigToJson(
-    GetBlockProductionConfig instance) {
-  final val = <String, dynamic>{};
+        GetBlockProductionConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.range?.toJson() case final value?) 'range': value,
+      if (instance.identity case final value?) 'identity': value,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('range', instance.range?.toJson());
-  writeNotNull('identity', instance.identity);
-  return val;
-}
-
-Map<String, dynamic> _$GetBlocksConfigToJson(GetBlocksConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  return val;
-}
+Map<String, dynamic> _$GetBlocksConfigToJson(GetBlocksConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+    };
 
 Map<String, dynamic> _$GetBlocksWithLimitConfigToJson(
-    GetBlocksWithLimitConfig instance) {
-  final val = <String, dynamic>{};
+        GetBlocksWithLimitConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  return val;
-}
-
-Map<String, dynamic> _$GetEpochInfoConfigToJson(GetEpochInfoConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+Map<String, dynamic> _$GetEpochInfoConfigToJson(GetEpochInfoConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetFeeForMessageConfigToJson(
-    GetFeeForMessageConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetFeeForMessageConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetInflationGovernorConfigToJson(
-    GetInflationGovernorConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  return val;
-}
+        GetInflationGovernorConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+    };
 
 Map<String, dynamic> _$GetInflationRewardConfigToJson(
-    GetInflationRewardConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('epoch', instance.epoch);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetInflationRewardConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.epoch case final value?) 'epoch': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetLargestAccountsConfigToJson(
-    GetLargestAccountsConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('filter', _$CirculationStatusEnumMap[instance.filter]);
-  return val;
-}
+        GetLargestAccountsConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (_$CirculationStatusEnumMap[instance.filter] case final value?)
+        'filter': value,
+    };
 
 const _$CirculationStatusEnumMap = {
   CirculationStatus.circulating: 'circulating',
@@ -214,367 +132,205 @@ const _$CirculationStatusEnumMap = {
 };
 
 Map<String, dynamic> _$GetLatestBlockhashConfigToJson(
-    GetLatestBlockhashConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetLatestBlockhashConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetLeaderScheduleConfigToJson(
-    GetLeaderScheduleConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('identity', instance.identity);
-  return val;
-}
+        GetLeaderScheduleConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.identity case final value?) 'identity': value,
+    };
 
 Map<String, dynamic> _$GetMinimumBalanceForRentExemptionConfigToJson(
-    GetMinimumBalanceForRentExemptionConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  return val;
-}
+        GetMinimumBalanceForRentExemptionConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+    };
 
 Map<String, dynamic> _$GetMultipleAccountsConfigToJson(
-    GetMultipleAccountsConfig instance) {
-  final val = <String, dynamic>{
-    'commitment': _$CommitmentEnumMap[instance.commitment]!,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('encoding', _$EncodingEnumMap[instance.encoding]);
-  writeNotNull('dataSlice', instance.dataSlice?.toJson());
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetMultipleAccountsConfig instance) =>
+    <String, dynamic>{
+      'commitment': _$CommitmentEnumMap[instance.commitment]!,
+      if (_$EncodingEnumMap[instance.encoding] case final value?)
+        'encoding': value,
+      if (instance.dataSlice?.toJson() case final value?) 'dataSlice': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetProgramAccountsConfigToJson(
-    GetProgramAccountsConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  val['encoding'] = _$EncodingEnumMap[instance.encoding]!;
-  writeNotNull('dataSlice', instance.dataSlice?.toJson());
-  writeNotNull('filters', instance.filters?.map((e) => e.toJson()).toList());
-  writeNotNull('withContext', instance.withContext);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetProgramAccountsConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      'encoding': _$EncodingEnumMap[instance.encoding]!,
+      if (instance.dataSlice?.toJson() case final value?) 'dataSlice': value,
+      if (instance.filters?.map((e) => e.toJson()).toList() case final value?)
+        'filters': value,
+      if (instance.withContext case final value?) 'withContext': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetSignaturesForAddressConfigToJson(
-    GetSignaturesForAddressConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('limit', instance.limit);
-  writeNotNull('before', instance.before);
-  writeNotNull('until', instance.until);
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetSignaturesForAddressConfig instance) =>
+    <String, dynamic>{
+      if (instance.limit case final value?) 'limit': value,
+      if (instance.before case final value?) 'before': value,
+      if (instance.until case final value?) 'until': value,
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetSignatureStatusesConfigToJson(
-    GetSignatureStatusesConfig instance) {
-  final val = <String, dynamic>{};
+        GetSignatureStatusesConfig instance) =>
+    <String, dynamic>{
+      if (instance.searchTransactionHistory case final value?)
+        'searchTransactionHistory': value,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
+Map<String, dynamic> _$GetSlotConfigToJson(GetSlotConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
-  writeNotNull('searchTransactionHistory', instance.searchTransactionHistory);
-  return val;
-}
-
-Map<String, dynamic> _$GetSlotConfigToJson(GetSlotConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
-
-Map<String, dynamic> _$GetSlotLeaderConfigToJson(GetSlotLeaderConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+Map<String, dynamic> _$GetSlotLeaderConfigToJson(
+        GetSlotLeaderConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetStakeMinimumDelegationConfigToJson(
-    GetStakeMinimumDelegationConfig instance) {
-  final val = <String, dynamic>{};
+        GetStakeMinimumDelegationConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  return val;
-}
-
-Map<String, dynamic> _$GetSupplyConfigToJson(GetSupplyConfig instance) {
-  final val = <String, dynamic>{
-    'commitment': _$CommitmentEnumMap[instance.commitment]!,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('excludeNonCirculatingAccountsList',
-      instance.excludeNonCirculatingAccountsList);
-  return val;
-}
+Map<String, dynamic> _$GetSupplyConfigToJson(GetSupplyConfig instance) =>
+    <String, dynamic>{
+      'commitment': _$CommitmentEnumMap[instance.commitment]!,
+      if (instance.excludeNonCirculatingAccountsList case final value?)
+        'excludeNonCirculatingAccountsList': value,
+    };
 
 Map<String, dynamic> _$GetTokenAccountBalanceConfigToJson(
-    GetTokenAccountBalanceConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  return val;
-}
+        GetTokenAccountBalanceConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+    };
 
 Map<String, dynamic> _$GetTokenAccountsByDelegateConfigToJson(
-    GetTokenAccountsByDelegateConfig instance) {
-  final val = <String, dynamic>{
-    'commitment': _$CommitmentEnumMap[instance.commitment]!,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('encoding', _$EncodingEnumMap[instance.encoding]);
-  writeNotNull('dataSlice', instance.dataSlice?.toJson());
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetTokenAccountsByDelegateConfig instance) =>
+    <String, dynamic>{
+      'commitment': _$CommitmentEnumMap[instance.commitment]!,
+      if (_$EncodingEnumMap[instance.encoding] case final value?)
+        'encoding': value,
+      if (instance.dataSlice?.toJson() case final value?) 'dataSlice': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetTokenAccountsByOwnerConfigToJson(
-    GetTokenAccountsByOwnerConfig instance) {
-  final val = <String, dynamic>{
-    'commitment': _$CommitmentEnumMap[instance.commitment]!,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('encoding', _$EncodingEnumMap[instance.encoding]);
-  writeNotNull('dataSlice', instance.dataSlice?.toJson());
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetTokenAccountsByOwnerConfig instance) =>
+    <String, dynamic>{
+      'commitment': _$CommitmentEnumMap[instance.commitment]!,
+      if (_$EncodingEnumMap[instance.encoding] case final value?)
+        'encoding': value,
+      if (instance.dataSlice?.toJson() case final value?) 'dataSlice': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetTokenLargestAccountsConfigToJson(
-    GetTokenLargestAccountsConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  return val;
-}
+        GetTokenLargestAccountsConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+    };
 
 Map<String, dynamic> _$GetTokenSupplyConfigToJson(
-    GetTokenSupplyConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  return val;
-}
+        GetTokenSupplyConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+    };
 
 Map<String, dynamic> _$GetTransactionConfigToJson(
-    GetTransactionConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('encoding', _$EncodingEnumMap[instance.encoding]);
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('maxSupportedTransactionVersion',
-      instance.maxSupportedTransactionVersion);
-  return val;
-}
+        GetTransactionConfig instance) =>
+    <String, dynamic>{
+      if (_$EncodingEnumMap[instance.encoding] case final value?)
+        'encoding': value,
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.maxSupportedTransactionVersion case final value?)
+        'maxSupportedTransactionVersion': value,
+    };
 
 Map<String, dynamic> _$GetTransactionCountConfigToJson(
-    GetTransactionCountConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        GetTransactionCountConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$GetVoteAccountsConfigToJson(
-    GetVoteAccountsConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('votePubKey', instance.votePubKey);
-  writeNotNull('keepUnstakedDelinquents', instance.keepUnstakedDelinquents);
-  writeNotNull('delinquentSlotDistance', instance.delinquentSlotDistance);
-  return val;
-}
+        GetVoteAccountsConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.votePubKey case final value?) 'votePubKey': value,
+      if (instance.keepUnstakedDelinquents case final value?)
+        'keepUnstakedDelinquents': value,
+      if (instance.delinquentSlotDistance case final value?)
+        'delinquentSlotDistance': value,
+    };
 
 Map<String, dynamic> _$IsBlockhashValidConfigToJson(
-    IsBlockhashValidConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        IsBlockhashValidConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$RequestAirdropConfigToJson(
-    RequestAirdropConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  return val;
-}
+        RequestAirdropConfig instance) =>
+    <String, dynamic>{
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+    };
 
 Map<String, dynamic> _$SendTransactionConfigToJson(
-    SendTransactionConfig instance) {
-  final val = <String, dynamic>{
-    'encoding': _$EncodingEnumMap[instance.encoding]!,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull(
-      'preflightCommitment', _$CommitmentEnumMap[instance.preflightCommitment]);
-  writeNotNull('skipPreflight', instance.skipPreflight);
-  writeNotNull('maxRetries', instance.maxRetries);
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        SendTransactionConfig instance) =>
+    <String, dynamic>{
+      'encoding': _$EncodingEnumMap[instance.encoding]!,
+      if (_$CommitmentEnumMap[instance.preflightCommitment] case final value?)
+        'preflightCommitment': value,
+      if (instance.skipPreflight case final value?) 'skipPreflight': value,
+      if (instance.maxRetries case final value?) 'maxRetries': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };
 
 Map<String, dynamic> _$SimulateTransactionConfigToJson(
-    SimulateTransactionConfig instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('sigVerify', instance.sigVerify);
-  val['encoding'] = _$EncodingEnumMap[instance.encoding]!;
-  writeNotNull('commitment', _$CommitmentEnumMap[instance.commitment]);
-  writeNotNull('replaceRecentBlockhash', instance.replaceRecentBlockhash);
-  writeNotNull('accounts', instance.accounts?.toJson());
-  writeNotNull('minContextSlot', instance.minContextSlot);
-  return val;
-}
+        SimulateTransactionConfig instance) =>
+    <String, dynamic>{
+      if (instance.sigVerify case final value?) 'sigVerify': value,
+      'encoding': _$EncodingEnumMap[instance.encoding]!,
+      if (_$CommitmentEnumMap[instance.commitment] case final value?)
+        'commitment': value,
+      if (instance.replaceRecentBlockhash case final value?)
+        'replaceRecentBlockhash': value,
+      if (instance.accounts?.toJson() case final value?) 'accounts': value,
+      if (instance.minContextSlot case final value?) 'minContextSlot': value,
+    };

--- a/packages/solana/lib/src/rpc/client.rpc.dart
+++ b/packages/solana/lib/src/rpc/client.rpc.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'client.dart';

--- a/packages/solana/lib/src/rpc/dto/account.g.dart
+++ b/packages/solana/lib/src/rpc/dto/account.g.dart
@@ -7,7 +7,7 @@ part of 'account.dart';
 // **************************************************************************
 
 Account _$AccountFromJson(Map<String, dynamic> json) => Account(
-      lamports: json['lamports'] as int,
+      lamports: (json['lamports'] as num).toInt(),
       owner: json['owner'] as String,
       data: json['data'] == null ? null : AccountData.fromJson(json['data']),
       executable: json['executable'] as bool,

--- a/packages/solana/lib/src/rpc/dto/account_data/parsed_account_data.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/account_data/parsed_account_data.freezed.dart
@@ -82,6 +82,8 @@ mixin _$ParsedAccountData {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this ParsedAccountData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
 
@@ -101,6 +103,9 @@ class _$ParsedAccountDataCopyWithImpl<$Res, $Val extends ParsedAccountData>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -125,6 +130,8 @@ class __$$ParsedSplTokenProgramAccountDataImplCopyWithImpl<$Res>
       $Res Function(_$ParsedSplTokenProgramAccountDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -138,6 +145,8 @@ class __$$ParsedSplTokenProgramAccountDataImplCopyWithImpl<$Res>
     ));
   }
 
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $SplTokenProgramAccountDataCopyWith<$Res> get parsed {
@@ -178,11 +187,13 @@ class _$ParsedSplTokenProgramAccountDataImpl
             (identical(other.parsed, parsed) || other.parsed == parsed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, parsed);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedSplTokenProgramAccountDataImplCopyWith<
@@ -283,7 +294,10 @@ abstract class ParsedSplTokenProgramAccountData implements ParsedAccountData {
 
   @override
   SplTokenProgramAccountData get parsed;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedSplTokenProgramAccountDataImplCopyWith<
           _$ParsedSplTokenProgramAccountDataImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -311,6 +325,8 @@ class __$$ParsedSplToken2022ProgramAccountDataImplCopyWithImpl<$Res>
       $Res Function(_$ParsedSplToken2022ProgramAccountDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -324,6 +340,8 @@ class __$$ParsedSplToken2022ProgramAccountDataImplCopyWithImpl<$Res>
     ));
   }
 
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $SplTokenProgramAccountDataCopyWith<$Res> get parsed {
@@ -364,11 +382,13 @@ class _$ParsedSplToken2022ProgramAccountDataImpl
             (identical(other.parsed, parsed) || other.parsed == parsed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, parsed);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedSplToken2022ProgramAccountDataImplCopyWith<
@@ -471,7 +491,10 @@ abstract class ParsedSplToken2022ProgramAccountData
 
   @override
   SplTokenProgramAccountData get parsed;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedSplToken2022ProgramAccountDataImplCopyWith<
           _$ParsedSplToken2022ProgramAccountDataImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -499,6 +522,8 @@ class __$$ParsedStakeProgramAccountDataImplCopyWithImpl<$Res>
       $Res Function(_$ParsedStakeProgramAccountDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -512,6 +537,8 @@ class __$$ParsedStakeProgramAccountDataImplCopyWithImpl<$Res>
     ));
   }
 
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $StakeProgramAccountDataCopyWith<$Res> get parsed {
@@ -551,11 +578,13 @@ class _$ParsedStakeProgramAccountDataImpl
             (identical(other.parsed, parsed) || other.parsed == parsed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, parsed);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedStakeProgramAccountDataImplCopyWith<
@@ -656,7 +685,10 @@ abstract class ParsedStakeProgramAccountData implements ParsedAccountData {
 
   @override
   StakeProgramAccountData get parsed;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedStakeProgramAccountDataImplCopyWith<
           _$ParsedStakeProgramAccountDataImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -682,6 +714,8 @@ class __$$UnsupportedProgramAccountDataImplCopyWithImpl<$Res>
       $Res Function(_$UnsupportedProgramAccountDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -733,12 +767,14 @@ class _$UnsupportedProgramAccountDataImpl
             const DeepCollectionEquality().equals(other._parsed, _parsed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_parsed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UnsupportedProgramAccountDataImplCopyWith<
@@ -838,7 +874,10 @@ abstract class UnsupportedProgramAccountData implements ParsedAccountData {
 
   @override
   Map<String, dynamic> get parsed;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UnsupportedProgramAccountDataImplCopyWith<
           _$UnsupportedProgramAccountDataImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/solana/lib/src/rpc/dto/account_data/spl_token_program/mint_account_data_info.g.dart
+++ b/packages/solana/lib/src/rpc/dto/account_data/spl_token_program/mint_account_data_info.g.dart
@@ -11,7 +11,7 @@ MintAccountDataInfo _$MintAccountDataInfoFromJson(Map<String, dynamic> json) =>
       mintAuthority: json['mintAuthority'] as String?,
       freezedAuthority: json['freezedAuthority'] as String?,
       isInitialized: json['isInitialized'] as bool,
-      decimals: json['decimals'] as int,
+      decimals: (json['decimals'] as num).toInt(),
       supply: json['supply'] as String,
     );
 

--- a/packages/solana/lib/src/rpc/dto/account_data/spl_token_program/token_account_data_info.g.dart
+++ b/packages/solana/lib/src/rpc/dto/account_data/spl_token_program/token_account_data_info.g.dart
@@ -23,22 +23,14 @@ SplTokenAccountDataInfo _$SplTokenAccountDataInfoFromJson(
     );
 
 Map<String, dynamic> _$SplTokenAccountDataInfoToJson(
-    SplTokenAccountDataInfo instance) {
-  final val = <String, dynamic>{
-    'tokenAmount': instance.tokenAmount.toJson(),
-    'state': instance.state,
-    'isNative': instance.isNative,
-    'mint': instance.mint,
-    'owner': instance.owner,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('delegate', instance.delegate);
-  writeNotNull('delegateAmount', instance.delegateAmount?.toJson());
-  return val;
-}
+        SplTokenAccountDataInfo instance) =>
+    <String, dynamic>{
+      'tokenAmount': instance.tokenAmount.toJson(),
+      'state': instance.state,
+      'isNative': instance.isNative,
+      'mint': instance.mint,
+      'owner': instance.owner,
+      if (instance.delegate case final value?) 'delegate': value,
+      if (instance.delegateAmount?.toJson() case final value?)
+        'delegateAmount': value,
+    };

--- a/packages/solana/lib/src/rpc/dto/account_data/spl_token_program/token_program_account_data.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/account_data/spl_token_program/token_program_account_data.freezed.dart
@@ -12,7 +12,7 @@ part of 'token_program_account_data.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 SplTokenProgramAccountData _$SplTokenProgramAccountDataFromJson(
     Map<String, dynamic> json) {
@@ -86,8 +86,13 @@ mixin _$SplTokenProgramAccountData {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this SplTokenProgramAccountData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SplTokenProgramAccountDataCopyWith<SplTokenProgramAccountData>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -113,6 +118,8 @@ class _$SplTokenProgramAccountDataCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -147,6 +154,8 @@ class __$$TokenAccountDataImplCopyWithImpl<$Res>
       $Res Function(_$TokenAccountDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -203,11 +212,13 @@ class _$TokenAccountDataImpl implements TokenAccountData {
                 other.accountType == accountType));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, info, type, accountType);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TokenAccountDataImplCopyWith<_$TokenAccountDataImpl> get copyWith =>
@@ -315,8 +326,11 @@ abstract class TokenAccountData implements SplTokenProgramAccountData {
   @override
   String get type;
   String? get accountType;
+
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TokenAccountDataImplCopyWith<_$TokenAccountDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -340,6 +354,8 @@ class __$$MintAccountDataImplCopyWithImpl<$Res>
       _$MintAccountDataImpl _value, $Res Function(_$MintAccountDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -396,11 +412,13 @@ class _$MintAccountDataImpl implements MintAccountData {
                 other.accountType == accountType));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, info, type, accountType);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MintAccountDataImplCopyWith<_$MintAccountDataImpl> get copyWith =>
@@ -508,8 +526,11 @@ abstract class MintAccountData implements SplTokenProgramAccountData {
   @override
   String get type;
   String? get accountType;
+
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MintAccountDataImplCopyWith<_$MintAccountDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -534,6 +555,8 @@ class __$$UnknownAccountDataImplCopyWithImpl<$Res>
       $Res Function(_$UnknownAccountDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -572,11 +595,13 @@ class _$UnknownAccountDataImpl implements UnknownAccountData {
             (identical(other.type, type) || other.type == type));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, type);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UnknownAccountDataImplCopyWith<_$UnknownAccountDataImpl> get copyWith =>
@@ -680,8 +705,11 @@ abstract class UnknownAccountData implements SplTokenProgramAccountData {
 
   @override
   String get type;
+
+  /// Create a copy of SplTokenProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UnknownAccountDataImplCopyWith<_$UnknownAccountDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/rpc/dto/account_data/stake_program/lockup.g.dart
+++ b/packages/solana/lib/src/rpc/dto/account_data/stake_program/lockup.g.dart
@@ -8,8 +8,8 @@ part of 'lockup.dart';
 
 Lockup _$LockupFromJson(Map<String, dynamic> json) => Lockup(
       custodian: json['custodian'] as String,
-      epoch: json['epoch'] as int,
-      unixTimestamp: json['unixTimestamp'] as int,
+      epoch: (json['epoch'] as num).toInt(),
+      unixTimestamp: (json['unixTimestamp'] as num).toInt(),
     );
 
 Map<String, dynamic> _$LockupToJson(Lockup instance) => <String, dynamic>{

--- a/packages/solana/lib/src/rpc/dto/account_data/stake_program/stake.g.dart
+++ b/packages/solana/lib/src/rpc/dto/account_data/stake_program/stake.g.dart
@@ -9,7 +9,7 @@ part of 'stake.dart';
 Stake _$StakeFromJson(Map<String, dynamic> json) => Stake(
       delegation:
           Delegation.fromJson(json['delegation'] as Map<String, dynamic>),
-      creditsObserved: json['creditsObserved'] as int,
+      creditsObserved: (json['creditsObserved'] as num).toInt(),
     );
 
 Map<String, dynamic> _$StakeToJson(Stake instance) => <String, dynamic>{

--- a/packages/solana/lib/src/rpc/dto/account_data/stake_program/stake_program_account_data.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/account_data/stake_program/stake_program_account_data.freezed.dart
@@ -12,7 +12,7 @@ part of 'stake_program_account_data.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 StakeProgramAccountData _$StakeProgramAccountDataFromJson(
     Map<String, dynamic> json) {
@@ -75,6 +75,8 @@ mixin _$StakeProgramAccountData {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this StakeProgramAccountData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
 
@@ -95,6 +97,9 @@ class _$StakeProgramAccountDataCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of StakeProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -117,6 +122,8 @@ class __$$StakeProgramDelegatedAccountDataImplCopyWithImpl<$Res>
       $Res Function(_$StakeProgramDelegatedAccountDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of StakeProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -162,11 +169,13 @@ class _$StakeProgramDelegatedAccountDataImpl
             (identical(other.info, info) || other.info == info));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, info);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of StakeProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StakeProgramDelegatedAccountDataImplCopyWith<
@@ -262,7 +271,10 @@ abstract class StakeProgramDelegatedAccountData
 
   @override
   StakeDelegatedAccountInfo get info;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of StakeProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StakeProgramDelegatedAccountDataImplCopyWith<
           _$StakeProgramDelegatedAccountDataImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -288,6 +300,8 @@ class __$$StakeProgramInitializedAccountDataImplCopyWithImpl<$Res>
       $Res Function(_$StakeProgramInitializedAccountDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of StakeProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -333,11 +347,13 @@ class _$StakeProgramInitializedAccountDataImpl
             (identical(other.info, info) || other.info == info));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, info);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of StakeProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StakeProgramInitializedAccountDataImplCopyWith<
@@ -434,7 +450,10 @@ abstract class StakeProgramInitializedAccountData
 
   @override
   StakeInitializedAccountInfo get info;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of StakeProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StakeProgramInitializedAccountDataImplCopyWith<
           _$StakeProgramInitializedAccountDataImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -460,6 +479,8 @@ class __$$StakeProgramUnknownAccountDataImplCopyWithImpl<$Res>
       $Res Function(_$StakeProgramUnknownAccountDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of StakeProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -511,12 +532,14 @@ class _$StakeProgramUnknownAccountDataImpl
             const DeepCollectionEquality().equals(other._info, _info));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_info));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of StakeProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StakeProgramUnknownAccountDataImplCopyWith<
@@ -611,7 +634,10 @@ abstract class StakeProgramUnknownAccountData
 
   @override
   Map<String, dynamic> get info;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of StakeProgramAccountData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StakeProgramUnknownAccountDataImplCopyWith<
           _$StakeProgramUnknownAccountDataImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/solana/lib/src/rpc/dto/address_table_lookups.g.dart
+++ b/packages/solana/lib/src/rpc/dto/address_table_lookups.g.dart
@@ -10,10 +10,10 @@ AddressTableLookups _$AddressTableLookupsFromJson(Map<String, dynamic> json) =>
     AddressTableLookups(
       accountKey: json['accountKey'] as String,
       writableIndexes: (json['writableIndexes'] as List<dynamic>)
-          .map((e) => e as int)
+          .map((e) => (e as num).toInt())
           .toList(),
       readonlyIndexes: (json['readonlyIndexes'] as List<dynamic>)
-          .map((e) => e as int)
+          .map((e) => (e as num).toInt())
           .toList(),
     );
 

--- a/packages/solana/lib/src/rpc/dto/balance.g.dart
+++ b/packages/solana/lib/src/rpc/dto/balance.g.dart
@@ -9,7 +9,7 @@ part of 'balance.dart';
 BalanceResult _$BalanceResultFromJson(Map<String, dynamic> json) =>
     BalanceResult(
       context: Context.fromJson(json['context'] as Map<String, dynamic>),
-      value: json['value'] as int,
+      value: (json['value'] as num).toInt(),
     );
 
 Map<String, dynamic> _$BalanceResultToJson(BalanceResult instance) =>

--- a/packages/solana/lib/src/rpc/dto/block.g.dart
+++ b/packages/solana/lib/src/rpc/dto/block.g.dart
@@ -9,7 +9,7 @@ part of 'block.dart';
 Block _$BlockFromJson(Map<String, dynamic> json) => Block(
       blockhash: json['blockhash'] as String,
       previousBlockhash: json['previousBlockhash'] as String,
-      parentSlot: json['parentSlot'] as int,
+      parentSlot: (json['parentSlot'] as num).toInt(),
       transactions: (json['transactions'] as List<dynamic>)
           .map(Transaction.fromJson)
           .toList(),
@@ -22,8 +22,8 @@ Block _$BlockFromJson(Map<String, dynamic> json) => Block(
       rewards: (json['rewards'] as List<dynamic>)
           .map((e) => Reward.fromJson(e as Map<String, dynamic>))
           .toList(),
-      blockTime: json['blockTime'] as int?,
-      blockHeight: json['blockHeight'] as int?,
+      blockTime: (json['blockTime'] as num?)?.toInt(),
+      blockHeight: (json['blockHeight'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$BlockToJson(Block instance) => <String, dynamic>{

--- a/packages/solana/lib/src/rpc/dto/block_commitment.g.dart
+++ b/packages/solana/lib/src/rpc/dto/block_commitment.g.dart
@@ -8,9 +8,10 @@ part of 'block_commitment.dart';
 
 BlockCommitment _$BlockCommitmentFromJson(Map<String, dynamic> json) =>
     BlockCommitment(
-      commitment:
-          (json['commitment'] as List<dynamic>?)?.map((e) => e as int).toList(),
-      totalStake: json['totalStake'] as int,
+      commitment: (json['commitment'] as List<dynamic>?)
+          ?.map((e) => (e as num).toInt())
+          .toList(),
+      totalStake: (json['totalStake'] as num).toInt(),
     );
 
 Map<String, dynamic> _$BlockCommitmentToJson(BlockCommitment instance) =>

--- a/packages/solana/lib/src/rpc/dto/cluster_node.g.dart
+++ b/packages/solana/lib/src/rpc/dto/cluster_node.g.dart
@@ -12,8 +12,8 @@ ClusterNode _$ClusterNodeFromJson(Map<String, dynamic> json) => ClusterNode(
       tpu: json['tpu'] as String?,
       rpc: json['rpc'] as String?,
       version: json['version'] as String?,
-      featureSet: json['featureSet'] as int?,
-      shredVersion: json['shredVersion'] as int?,
+      featureSet: (json['featureSet'] as num?)?.toInt(),
+      shredVersion: (json['shredVersion'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$ClusterNodeToJson(ClusterNode instance) =>

--- a/packages/solana/lib/src/rpc/dto/data_slice.g.dart
+++ b/packages/solana/lib/src/rpc/dto/data_slice.g.dart
@@ -7,20 +7,11 @@ part of 'data_slice.dart';
 // **************************************************************************
 
 DataSlice _$DataSliceFromJson(Map<String, dynamic> json) => DataSlice(
-      offset: json['offset'] as int?,
-      length: json['length'] as int?,
+      offset: (json['offset'] as num?)?.toInt(),
+      length: (json['length'] as num?)?.toInt(),
     );
 
-Map<String, dynamic> _$DataSliceToJson(DataSlice instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('offset', instance.offset);
-  writeNotNull('length', instance.length);
-  return val;
-}
+Map<String, dynamic> _$DataSliceToJson(DataSlice instance) => <String, dynamic>{
+      if (instance.offset case final value?) 'offset': value,
+      if (instance.length case final value?) 'length': value,
+    };

--- a/packages/solana/lib/src/rpc/dto/epoch_info.g.dart
+++ b/packages/solana/lib/src/rpc/dto/epoch_info.g.dart
@@ -7,12 +7,12 @@ part of 'epoch_info.dart';
 // **************************************************************************
 
 EpochInfo _$EpochInfoFromJson(Map<String, dynamic> json) => EpochInfo(
-      absoluteSlot: json['absoluteSlot'] as int,
-      blockHeight: json['blockHeight'] as int,
-      epoch: json['epoch'] as int,
-      slotIndex: json['slotIndex'] as int,
-      slotsInEpoch: json['slotsInEpoch'] as int,
-      transactionCount: json['transactionCount'] as int?,
+      absoluteSlot: (json['absoluteSlot'] as num).toInt(),
+      blockHeight: (json['blockHeight'] as num).toInt(),
+      epoch: (json['epoch'] as num).toInt(),
+      slotIndex: (json['slotIndex'] as num).toInt(),
+      slotsInEpoch: (json['slotsInEpoch'] as num).toInt(),
+      transactionCount: (json['transactionCount'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$EpochInfoToJson(EpochInfo instance) => <String, dynamic>{

--- a/packages/solana/lib/src/rpc/dto/epoch_schedule.g.dart
+++ b/packages/solana/lib/src/rpc/dto/epoch_schedule.g.dart
@@ -8,11 +8,12 @@ part of 'epoch_schedule.dart';
 
 EpochSchedule _$EpochScheduleFromJson(Map<String, dynamic> json) =>
     EpochSchedule(
-      slotsPerEpoch: json['slotsPerEpoch'] as int,
-      leaderScheduleSlotOffset: json['leaderScheduleSlotOffset'] as int,
+      slotsPerEpoch: (json['slotsPerEpoch'] as num).toInt(),
+      leaderScheduleSlotOffset:
+          (json['leaderScheduleSlotOffset'] as num).toInt(),
       warmup: json['warmup'] as bool,
-      firstNormalEpoch: json['firstNormalEpoch'] as int,
-      firstNormalSlot: json['firstNormalSlot'] as int,
+      firstNormalEpoch: (json['firstNormalEpoch'] as num).toInt(),
+      firstNormalSlot: (json['firstNormalSlot'] as num).toInt(),
     );
 
 Map<String, dynamic> _$EpochScheduleToJson(EpochSchedule instance) =>

--- a/packages/solana/lib/src/rpc/dto/fee_calculator.g.dart
+++ b/packages/solana/lib/src/rpc/dto/fee_calculator.g.dart
@@ -8,7 +8,7 @@ part of 'fee_calculator.dart';
 
 FeeCalculator _$FeeCalculatorFromJson(Map<String, dynamic> json) =>
     FeeCalculator(
-      lamportsPerSignature: json['lamportsPerSignature'] as int,
+      lamportsPerSignature: (json['lamportsPerSignature'] as num).toInt(),
     );
 
 Map<String, dynamic> _$FeeCalculatorToJson(FeeCalculator instance) =>

--- a/packages/solana/lib/src/rpc/dto/fee_rate_governor_value.g.dart
+++ b/packages/solana/lib/src/rpc/dto/fee_rate_governor_value.g.dart
@@ -9,11 +9,12 @@ part of 'fee_rate_governor_value.dart';
 FeeRateGovernorValue _$FeeRateGovernorValueFromJson(
         Map<String, dynamic> json) =>
     FeeRateGovernorValue(
-      burnPercent: json['burnPercent'] as int,
-      maxLamportsPerSignature: json['maxLamportsPerSignature'] as int,
-      minLamportsPerSignature: json['minLamportsPerSignature'] as int,
-      targetLamportsPerSignature: json['targetLamportsPerSignature'] as int,
-      targetSignaturesPerSlot: json['targetSignaturesPerSlot'] as int,
+      burnPercent: (json['burnPercent'] as num).toInt(),
+      maxLamportsPerSignature: (json['maxLamportsPerSignature'] as num).toInt(),
+      minLamportsPerSignature: (json['minLamportsPerSignature'] as num).toInt(),
+      targetLamportsPerSignature:
+          (json['targetLamportsPerSignature'] as num).toInt(),
+      targetSignaturesPerSlot: (json['targetSignaturesPerSlot'] as num).toInt(),
     );
 
 Map<String, dynamic> _$FeeRateGovernorValueToJson(

--- a/packages/solana/lib/src/rpc/dto/fees.g.dart
+++ b/packages/solana/lib/src/rpc/dto/fees.g.dart
@@ -10,7 +10,7 @@ Fees _$FeesFromJson(Map<String, dynamic> json) => Fees(
       blockhash: json['blockhash'] as String,
       feeCalculator:
           FeeCalculator.fromJson(json['feeCalculator'] as Map<String, dynamic>),
-      lastValidBlockHeight: json['lastValidBlockHeight'] as int,
+      lastValidBlockHeight: (json['lastValidBlockHeight'] as num).toInt(),
     );
 
 Map<String, dynamic> _$FeesToJson(Fees instance) => <String, dynamic>{

--- a/packages/solana/lib/src/rpc/dto/highest_snapshot_slot.g.dart
+++ b/packages/solana/lib/src/rpc/dto/highest_snapshot_slot.g.dart
@@ -8,8 +8,8 @@ part of 'highest_snapshot_slot.dart';
 
 HighestSnapshotSlot _$HighestSnapshotSlotFromJson(Map<String, dynamic> json) =>
     HighestSnapshotSlot(
-      full: json['full'] as int,
-      incremental: json['incremental'] as int?,
+      full: (json['full'] as num).toInt(),
+      incremental: (json['incremental'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$HighestSnapshotSlotToJson(

--- a/packages/solana/lib/src/rpc/dto/inflation_reward.g.dart
+++ b/packages/solana/lib/src/rpc/dto/inflation_reward.g.dart
@@ -8,11 +8,11 @@ part of 'inflation_reward.dart';
 
 InflationReward _$InflationRewardFromJson(Map<String, dynamic> json) =>
     InflationReward(
-      epoch: json['epoch'] as int,
-      effectiveSlot: json['effectiveSlot'] as int,
-      amount: json['amount'] as int,
-      postBalance: json['postBalance'] as int,
-      commission: json['commission'] as int,
+      epoch: (json['epoch'] as num).toInt(),
+      effectiveSlot: (json['effectiveSlot'] as num).toInt(),
+      amount: (json['amount'] as num).toInt(),
+      postBalance: (json['postBalance'] as num).toInt(),
+      commission: (json['commission'] as num).toInt(),
     );
 
 Map<String, dynamic> _$InflationRewardToJson(InflationReward instance) =>

--- a/packages/solana/lib/src/rpc/dto/inner_instruction.g.dart
+++ b/packages/solana/lib/src/rpc/dto/inner_instruction.g.dart
@@ -8,7 +8,7 @@ part of 'inner_instruction.dart';
 
 InnerInstruction _$InnerInstructionFromJson(Map<String, dynamic> json) =>
     InnerInstruction(
-      index: json['index'] as int,
+      index: (json['index'] as num).toInt(),
       instructions: (json['instructions'] as List<dynamic>)
           .map((e) => Instruction.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/packages/solana/lib/src/rpc/dto/large_account.g.dart
+++ b/packages/solana/lib/src/rpc/dto/large_account.g.dart
@@ -8,7 +8,7 @@ part of 'large_account.dart';
 
 LargeAccount _$LargeAccountFromJson(Map<String, dynamic> json) => LargeAccount(
       address: json['address'] as String,
-      lamports: json['lamports'] as int,
+      lamports: (json['lamports'] as num).toInt(),
     );
 
 Map<String, dynamic> _$LargeAccountToJson(LargeAccount instance) =>

--- a/packages/solana/lib/src/rpc/dto/latest_blockhash.g.dart
+++ b/packages/solana/lib/src/rpc/dto/latest_blockhash.g.dart
@@ -9,7 +9,7 @@ part of 'latest_blockhash.dart';
 LatestBlockhash _$LatestBlockhashFromJson(Map<String, dynamic> json) =>
     LatestBlockhash(
       blockhash: json['blockhash'] as String,
-      lastValidBlockHeight: json['lastValidBlockHeight'] as int,
+      lastValidBlockHeight: (json['lastValidBlockHeight'] as num).toInt(),
     );
 
 Map<String, dynamic> _$LatestBlockhashToJson(LatestBlockhash instance) =>

--- a/packages/solana/lib/src/rpc/dto/meta.g.dart
+++ b/packages/solana/lib/src/rpc/dto/meta.g.dart
@@ -8,11 +8,13 @@ part of 'meta.dart';
 
 Meta _$MetaFromJson(Map<String, dynamic> json) => Meta(
       err: json['err'] as Map<String, dynamic>?,
-      fee: json['fee'] as int,
-      preBalances:
-          (json['preBalances'] as List<dynamic>).map((e) => e as int).toList(),
-      postBalances:
-          (json['postBalances'] as List<dynamic>).map((e) => e as int).toList(),
+      fee: (json['fee'] as num).toInt(),
+      preBalances: (json['preBalances'] as List<dynamic>)
+          .map((e) => (e as num).toInt())
+          .toList(),
+      postBalances: (json['postBalances'] as List<dynamic>)
+          .map((e) => (e as num).toInt())
+          .toList(),
       innerInstructions: (json['innerInstructions'] as List<dynamic>?)
           ?.map((e) => InnerInstruction.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -35,7 +37,7 @@ Meta _$MetaFromJson(Map<String, dynamic> json) => Meta(
       returnData: json['returnData'] == null
           ? null
           : ReturnData.fromJson(json['returnData'] as Map<String, dynamic>),
-      computeUnitsConsumed: json['computeUnitsConsumed'] as int?,
+      computeUnitsConsumed: (json['computeUnitsConsumed'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$MetaToJson(Meta instance) => <String, dynamic>{

--- a/packages/solana/lib/src/rpc/dto/parsed_message/header.g.dart
+++ b/packages/solana/lib/src/rpc/dto/parsed_message/header.g.dart
@@ -7,9 +7,11 @@ part of 'header.dart';
 // **************************************************************************
 
 Header _$HeaderFromJson(Map<String, dynamic> json) => Header(
-      numRequiredSignatures: json['numRequiredSignatures'] as int,
-      numReadonlySignedAccounts: json['numReadonlySignedAccounts'] as int,
-      numReadonlyUnsignedAccounts: json['numReadonlyUnsignedAccounts'] as int,
+      numRequiredSignatures: (json['numRequiredSignatures'] as num).toInt(),
+      numReadonlySignedAccounts:
+          (json['numReadonlySignedAccounts'] as num).toInt(),
+      numReadonlyUnsignedAccounts:
+          (json['numReadonlyUnsignedAccounts'] as num).toInt(),
     );
 
 Map<String, dynamic> _$HeaderToJson(Header instance) => <String, dynamic>{

--- a/packages/solana/lib/src/rpc/dto/parsed_message/parsed_instruction.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/parsed_message/parsed_instruction.freezed.dart
@@ -12,7 +12,7 @@ part of 'parsed_instruction.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 ParsedInstruction _$ParsedInstructionFromJson(Map<String, dynamic> json) {
   switch (json['program']) {
@@ -81,6 +81,8 @@ mixin _$ParsedInstruction {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this ParsedInstruction to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
 
@@ -100,6 +102,9 @@ class _$ParsedInstructionCopyWithImpl<$Res, $Val extends ParsedInstruction>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -123,6 +128,8 @@ class __$$ParsedInstructionSystemImplCopyWithImpl<$Res>
       $Res Function(_$ParsedInstructionSystemImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -141,6 +148,8 @@ class __$$ParsedInstructionSystemImplCopyWithImpl<$Res>
     ));
   }
 
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ParsedSystemInstructionCopyWith<$Res> get parsed {
@@ -183,11 +192,13 @@ class _$ParsedInstructionSystemImpl implements ParsedInstructionSystem {
             (identical(other.parsed, parsed) || other.parsed == parsed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, programId, parsed);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedInstructionSystemImplCopyWith<_$ParsedInstructionSystemImpl>
@@ -288,7 +299,10 @@ abstract class ParsedInstructionSystem implements ParsedInstruction {
 
   String get programId;
   ParsedSystemInstruction get parsed;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedInstructionSystemImplCopyWith<_$ParsedInstructionSystemImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -315,6 +329,8 @@ class __$$ParsedInstructionSplTokenImplCopyWithImpl<$Res>
       $Res Function(_$ParsedInstructionSplTokenImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -328,6 +344,8 @@ class __$$ParsedInstructionSplTokenImplCopyWithImpl<$Res>
     ));
   }
 
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ParsedSplTokenInstructionCopyWith<$Res> get parsed {
@@ -366,11 +384,13 @@ class _$ParsedInstructionSplTokenImpl implements ParsedInstructionSplToken {
             (identical(other.parsed, parsed) || other.parsed == parsed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, parsed);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedInstructionSplTokenImplCopyWith<_$ParsedInstructionSplTokenImpl>
@@ -469,7 +489,10 @@ abstract class ParsedInstructionSplToken implements ParsedInstruction {
       _$ParsedInstructionSplTokenImpl.fromJson;
 
   ParsedSplTokenInstruction get parsed;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedInstructionSplTokenImplCopyWith<_$ParsedInstructionSplTokenImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -492,6 +515,8 @@ class __$$ParsedInstructionMemoImplCopyWithImpl<$Res>
       $Res Function(_$ParsedInstructionMemoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -538,11 +563,13 @@ class _$ParsedInstructionMemoImpl implements ParsedInstructionMemo {
             (identical(other.memo, memo) || other.memo == memo));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, memo);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedInstructionMemoImplCopyWith<_$ParsedInstructionMemoImpl>
@@ -644,7 +671,10 @@ abstract class ParsedInstructionMemo implements ParsedInstruction {
 // ignore: invalid_annotation_target
   @JsonKey(name: 'parsed')
   String? get memo;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedInstructionMemoImplCopyWith<_$ParsedInstructionMemoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -669,6 +699,8 @@ class __$$ParsedInstructionUnsupportedImplCopyWithImpl<$Res>
       $Res Function(_$ParsedInstructionUnsupportedImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -709,11 +741,13 @@ class _$ParsedInstructionUnsupportedImpl
             (identical(other.program, program) || other.program == program));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, program);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedInstructionUnsupportedImplCopyWith<
@@ -812,7 +846,10 @@ abstract class ParsedInstructionUnsupported implements ParsedInstruction {
       _$ParsedInstructionUnsupportedImpl.fromJson;
 
   String? get program;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedInstructionUnsupportedImplCopyWith<
           _$ParsedInstructionUnsupportedImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/solana/lib/src/rpc/dto/parsed_message/parsed_spl_token_instruction.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/parsed_message/parsed_spl_token_instruction.freezed.dart
@@ -12,7 +12,7 @@ part of 'parsed_spl_token_instruction.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 ParsedSplTokenInstruction _$ParsedSplTokenInstructionFromJson(
     Map<String, dynamic> json) {
@@ -81,8 +81,13 @@ mixin _$ParsedSplTokenInstruction {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this ParsedSplTokenInstruction to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ParsedSplTokenInstructionCopyWith<ParsedSplTokenInstruction> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -107,6 +112,8 @@ class _$ParsedSplTokenInstructionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -143,6 +150,8 @@ class __$$ParsedSplTokenTransferInstructionImplCopyWithImpl<$Res>
       $Res Function(_$ParsedSplTokenTransferInstructionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -192,11 +201,13 @@ class _$ParsedSplTokenTransferInstructionImpl
             (identical(other.type, type) || other.type == type));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, info, type);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedSplTokenTransferInstructionImplCopyWith<
@@ -300,8 +311,11 @@ abstract class ParsedSplTokenTransferInstruction
   SplTokenTransferInfo get info;
   @override
   String get type;
+
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedSplTokenTransferInstructionImplCopyWith<
           _$ParsedSplTokenTransferInstructionImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -329,6 +343,8 @@ class __$$ParsedSplTokenTransferCheckedInstructionImplCopyWithImpl<$Res>
       $Res Function(_$ParsedSplTokenTransferCheckedInstructionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -378,11 +394,13 @@ class _$ParsedSplTokenTransferCheckedInstructionImpl
             (identical(other.type, type) || other.type == type));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, info, type);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedSplTokenTransferCheckedInstructionImplCopyWith<
@@ -488,8 +506,11 @@ abstract class ParsedSplTokenTransferCheckedInstruction
   SplTokenTransferCheckedInfo get info;
   @override
   String get type;
+
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedSplTokenTransferCheckedInstructionImplCopyWith<
           _$ParsedSplTokenTransferCheckedInstructionImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -517,6 +538,8 @@ class __$$ParsedSplTokenGenericInstructionImplCopyWithImpl<$Res>
       $Res Function(_$ParsedSplTokenGenericInstructionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -566,12 +589,14 @@ class _$ParsedSplTokenGenericInstructionImpl
             (identical(other.type, type) || other.type == type));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(info), type);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedSplTokenGenericInstructionImplCopyWith<
@@ -674,8 +699,11 @@ abstract class ParsedSplTokenGenericInstruction
   dynamic get info;
   @override
   String get type;
+
+  /// Create a copy of ParsedSplTokenInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedSplTokenGenericInstructionImplCopyWith<
           _$ParsedSplTokenGenericInstructionImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/solana/lib/src/rpc/dto/parsed_message/parsed_system_instruction.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/parsed_message/parsed_system_instruction.freezed.dart
@@ -12,7 +12,7 @@ part of 'parsed_system_instruction.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 ParsedSystemInstruction _$ParsedSystemInstructionFromJson(
     Map<String, dynamic> json) {
@@ -84,8 +84,13 @@ mixin _$ParsedSystemInstruction {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this ParsedSystemInstruction to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ParsedSystemInstructionCopyWith<ParsedSystemInstruction> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -110,6 +115,8 @@ class _$ParsedSystemInstructionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -148,6 +155,8 @@ class __$$ParsedSystemTransferInstructionImplCopyWithImpl<$Res>
       $Res Function(_$ParsedSystemTransferInstructionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -166,6 +175,8 @@ class __$$ParsedSystemTransferInstructionImplCopyWithImpl<$Res>
     ));
   }
 
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ParsedSystemTransferInformationCopyWith<$Res> get info {
@@ -205,11 +216,13 @@ class _$ParsedSystemTransferInstructionImpl
             (identical(other.type, type) || other.type == type));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, info, type);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedSystemTransferInstructionImplCopyWith<
@@ -315,8 +328,11 @@ abstract class ParsedSystemTransferInstruction
   ParsedSystemTransferInformation get info;
   @override
   String get type;
+
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedSystemTransferInstructionImplCopyWith<
           _$ParsedSystemTransferInstructionImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -346,6 +362,8 @@ class __$$ParsedSystemTransferCheckedInstructionImplCopyWithImpl<$Res>
       $Res Function(_$ParsedSystemTransferCheckedInstructionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -364,6 +382,8 @@ class __$$ParsedSystemTransferCheckedInstructionImplCopyWithImpl<$Res>
     ));
   }
 
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ParsedSystemTransferInformationCopyWith<$Res> get info {
@@ -403,11 +423,13 @@ class _$ParsedSystemTransferCheckedInstructionImpl
             (identical(other.type, type) || other.type == type));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, info, type);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedSystemTransferCheckedInstructionImplCopyWith<
@@ -516,8 +538,11 @@ abstract class ParsedSystemTransferCheckedInstruction
   ParsedSystemTransferInformation get info;
   @override
   String get type;
+
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedSystemTransferCheckedInstructionImplCopyWith<
           _$ParsedSystemTransferCheckedInstructionImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -545,6 +570,8 @@ class __$$ParsedSystemUnsupportedInstructionImplCopyWithImpl<$Res>
       $Res Function(_$ParsedSystemUnsupportedInstructionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -585,11 +612,13 @@ class _$ParsedSystemUnsupportedInstructionImpl
             (identical(other.type, type) || other.type == type));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, type);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedSystemUnsupportedInstructionImplCopyWith<
@@ -694,8 +723,11 @@ abstract class ParsedSystemUnsupportedInstruction
 
   @override
   String get type;
+
+  /// Create a copy of ParsedSystemInstruction
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedSystemUnsupportedInstructionImplCopyWith<
           _$ParsedSystemUnsupportedInstructionImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -712,8 +744,12 @@ mixin _$ParsedSystemTransferInformation {
   String get source => throw _privateConstructorUsedError;
   String get destination => throw _privateConstructorUsedError;
 
+  /// Serializes this ParsedSystemTransferInformation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ParsedSystemTransferInformation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ParsedSystemTransferInformationCopyWith<ParsedSystemTransferInformation>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -740,6 +776,8 @@ class _$ParsedSystemTransferInformationCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ParsedSystemTransferInformation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -786,6 +824,8 @@ class __$$ParsedSystemTransferInformationImplCopyWithImpl<$Res>
       $Res Function(_$ParsedSystemTransferInformationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ParsedSystemTransferInformation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -847,11 +887,13 @@ class _$ParsedSystemTransferInformationImpl
                 other.destination == destination));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, lamports, source, destination);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ParsedSystemTransferInformation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ParsedSystemTransferInformationImplCopyWith<
@@ -884,8 +926,11 @@ abstract class _ParsedSystemTransferInformation
   String get source;
   @override
   String get destination;
+
+  /// Create a copy of ParsedSystemTransferInformation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ParsedSystemTransferInformationImplCopyWith<
           _$ParsedSystemTransferInformationImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/solana/lib/src/rpc/dto/parsed_message/parsed_system_instruction.g.dart
+++ b/packages/solana/lib/src/rpc/dto/parsed_message/parsed_system_instruction.g.dart
@@ -53,7 +53,7 @@ Map<String, dynamic> _$$ParsedSystemUnsupportedInstructionImplToJson(
 _$ParsedSystemTransferInformationImpl
     _$$ParsedSystemTransferInformationImplFromJson(Map<String, dynamic> json) =>
         _$ParsedSystemTransferInformationImpl(
-          lamports: json['lamports'] as int,
+          lamports: (json['lamports'] as num).toInt(),
           source: json['source'] as String,
           destination: json['destination'] as String,
         );

--- a/packages/solana/lib/src/rpc/dto/perf_sample.g.dart
+++ b/packages/solana/lib/src/rpc/dto/perf_sample.g.dart
@@ -7,10 +7,10 @@ part of 'perf_sample.dart';
 // **************************************************************************
 
 PerfSample _$PerfSampleFromJson(Map<String, dynamic> json) => PerfSample(
-      slot: json['slot'] as int,
-      numTransactions: json['numTransactions'] as int,
-      numSlots: json['numSlots'] as int,
-      samplePeriodSecs: json['samplePeriodSecs'] as int,
+      slot: (json['slot'] as num).toInt(),
+      numTransactions: (json['numTransactions'] as num).toInt(),
+      numSlots: (json['numSlots'] as num).toInt(),
+      samplePeriodSecs: (json['samplePeriodSecs'] as num).toInt(),
     );
 
 Map<String, dynamic> _$PerfSampleToJson(PerfSample instance) =>

--- a/packages/solana/lib/src/rpc/dto/range.g.dart
+++ b/packages/solana/lib/src/rpc/dto/range.g.dart
@@ -7,8 +7,8 @@ part of 'range.dart';
 // **************************************************************************
 
 Range _$RangeFromJson(Map<String, dynamic> json) => Range(
-      firstSlot: json['firstSlot'] as int,
-      lastSlot: json['lastSlot'] as int,
+      firstSlot: (json['firstSlot'] as num).toInt(),
+      lastSlot: (json['lastSlot'] as num).toInt(),
     );
 
 Map<String, dynamic> _$RangeToJson(Range instance) => <String, dynamic>{

--- a/packages/solana/lib/src/rpc/dto/raw_instruction.g.dart
+++ b/packages/solana/lib/src/rpc/dto/raw_instruction.g.dart
@@ -8,9 +8,10 @@ part of 'raw_instruction.dart';
 
 RawInstruction _$RawInstructionFromJson(Map<String, dynamic> json) =>
     RawInstruction(
-      programIdIndex: json['programIdIndex'] as int,
-      accounts:
-          (json['accounts'] as List<dynamic>).map((e) => e as int).toList(),
+      programIdIndex: (json['programIdIndex'] as num).toInt(),
+      accounts: (json['accounts'] as List<dynamic>)
+          .map((e) => (e as num).toInt())
+          .toList(),
       data: json['data'] as String,
     );
 

--- a/packages/solana/lib/src/rpc/dto/reward.g.dart
+++ b/packages/solana/lib/src/rpc/dto/reward.g.dart
@@ -8,10 +8,10 @@ part of 'reward.dart';
 
 Reward _$RewardFromJson(Map<String, dynamic> json) => Reward(
       pubkey: json['pubkey'] as String,
-      lamports: json['lamports'] as int,
-      postBalance: json['postBalance'] as int,
+      lamports: (json['lamports'] as num).toInt(),
+      postBalance: (json['postBalance'] as num).toInt(),
       rewardType: $enumDecode(_$RewardTypeEnumMap, json['rewardType']),
-      commission: json['commission'] as int,
+      commission: (json['commission'] as num).toInt(),
     );
 
 Map<String, dynamic> _$RewardToJson(Reward instance) => <String, dynamic>{

--- a/packages/solana/lib/src/rpc/dto/signature_status.g.dart
+++ b/packages/solana/lib/src/rpc/dto/signature_status.g.dart
@@ -8,10 +8,10 @@ part of 'signature_status.dart';
 
 SignatureStatus _$SignatureStatusFromJson(Map<String, dynamic> json) =>
     SignatureStatus(
-      slot: json['slot'] as int,
+      slot: (json['slot'] as num).toInt(),
       confirmationStatus:
           $enumDecode(_$CommitmentEnumMap, json['confirmationStatus']),
-      confirmations: json['confirmations'] as int?,
+      confirmations: (json['confirmations'] as num?)?.toInt(),
       err: json['err'] as Map<String, dynamic>?,
     );
 

--- a/packages/solana/lib/src/rpc/dto/simulate_transaction_accounts.g.dart
+++ b/packages/solana/lib/src/rpc/dto/simulate_transaction_accounts.g.dart
@@ -16,19 +16,12 @@ SimulateTransactionAccounts _$SimulateTransactionAccountsFromJson(
     );
 
 Map<String, dynamic> _$SimulateTransactionAccountsToJson(
-    SimulateTransactionAccounts instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('encoding', _$EncodingEnumMap[instance.encoding]);
-  writeNotNull('addresses', instance.addresses);
-  return val;
-}
+        SimulateTransactionAccounts instance) =>
+    <String, dynamic>{
+      if (_$EncodingEnumMap[instance.encoding] case final value?)
+        'encoding': value,
+      if (instance.addresses case final value?) 'addresses': value,
+    };
 
 const _$EncodingEnumMap = {
   Encoding.base64: 'base64',

--- a/packages/solana/lib/src/rpc/dto/slot.g.dart
+++ b/packages/solana/lib/src/rpc/dto/slot.g.dart
@@ -7,8 +7,8 @@ part of 'slot.dart';
 // **************************************************************************
 
 Slot _$SlotFromJson(Map<String, dynamic> json) => Slot(
-      parent: json['parent'] as int,
-      slot: json['slot'] as int,
+      parent: (json['parent'] as num).toInt(),
+      slot: (json['slot'] as num).toInt(),
       type: json['type'] as String,
     );
 

--- a/packages/solana/lib/src/rpc/dto/solana_version.g.dart
+++ b/packages/solana/lib/src/rpc/dto/solana_version.g.dart
@@ -9,7 +9,7 @@ part of 'solana_version.dart';
 SolanaVersion _$SolanaVersionFromJson(Map<String, dynamic> json) =>
     SolanaVersion(
       solanaCore: json['solana-core'] as String,
-      featureSet: json['feature-set'] as int,
+      featureSet: (json['feature-set'] as num).toInt(),
     );
 
 Map<String, dynamic> _$SolanaVersionToJson(SolanaVersion instance) =>

--- a/packages/solana/lib/src/rpc/dto/stake_activation.g.dart
+++ b/packages/solana/lib/src/rpc/dto/stake_activation.g.dart
@@ -9,8 +9,8 @@ part of 'stake_activation.dart';
 StakeActivation _$StakeActivationFromJson(Map<String, dynamic> json) =>
     StakeActivation(
       state: $enumDecode(_$StakeActivationStateEnumMap, json['state']),
-      active: json['active'] as int,
-      inactive: json['inactive'] as int,
+      active: (json['active'] as num).toInt(),
+      inactive: (json['inactive'] as num).toInt(),
     );
 
 Map<String, dynamic> _$StakeActivationToJson(StakeActivation instance) =>

--- a/packages/solana/lib/src/rpc/dto/stake_minimum_delegation.g.dart
+++ b/packages/solana/lib/src/rpc/dto/stake_minimum_delegation.g.dart
@@ -10,7 +10,7 @@ StakeMinimumDelegationResult _$StakeMinimumDelegationResultFromJson(
         Map<String, dynamic> json) =>
     StakeMinimumDelegationResult(
       context: Context.fromJson(json['context'] as Map<String, dynamic>),
-      value: json['value'] as int,
+      value: (json['value'] as num).toInt(),
     );
 
 Map<String, dynamic> _$StakeMinimumDelegationResultToJson(

--- a/packages/solana/lib/src/rpc/dto/supply.g.dart
+++ b/packages/solana/lib/src/rpc/dto/supply.g.dart
@@ -7,9 +7,9 @@ part of 'supply.dart';
 // **************************************************************************
 
 Supply _$SupplyFromJson(Map<String, dynamic> json) => Supply(
-      total: json['total'] as int,
-      circulating: json['circulating'] as int,
-      nonCirculating: json['nonCirculating'] as int,
+      total: (json['total'] as num).toInt(),
+      circulating: (json['circulating'] as num).toInt(),
+      nonCirculating: (json['nonCirculating'] as num).toInt(),
       nonCirculatingAccounts: (json['nonCirculatingAccounts'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),

--- a/packages/solana/lib/src/rpc/dto/token_amount.g.dart
+++ b/packages/solana/lib/src/rpc/dto/token_amount.g.dart
@@ -8,7 +8,7 @@ part of 'token_amount.dart';
 
 TokenAmount _$TokenAmountFromJson(Map<String, dynamic> json) => TokenAmount(
       amount: json['amount'] as String,
-      decimals: json['decimals'] as int,
+      decimals: (json['decimals'] as num).toInt(),
       uiAmountString: json['uiAmountString'] as String?,
     );
 

--- a/packages/solana/lib/src/rpc/dto/token_balance.g.dart
+++ b/packages/solana/lib/src/rpc/dto/token_balance.g.dart
@@ -7,7 +7,7 @@ part of 'token_balance.dart';
 // **************************************************************************
 
 TokenBalance _$TokenBalanceFromJson(Map<String, dynamic> json) => TokenBalance(
-      accountIndex: json['accountIndex'] as int,
+      accountIndex: (json['accountIndex'] as num).toInt(),
       mint: json['mint'] as String,
       uiTokenAmount:
           TokenAmount.fromJson(json['uiTokenAmount'] as Map<String, dynamic>),

--- a/packages/solana/lib/src/rpc/dto/token_largest_account.g.dart
+++ b/packages/solana/lib/src/rpc/dto/token_largest_account.g.dart
@@ -10,7 +10,7 @@ TokenLargestAccount _$TokenLargestAccountFromJson(Map<String, dynamic> json) =>
     TokenLargestAccount(
       address: json['address'] as String,
       amount: json['amount'] as String,
-      decimals: json['decimals'] as int,
+      decimals: (json['decimals'] as num).toInt(),
       uiAmountString: json['uiAmountString'] as String,
     );
 

--- a/packages/solana/lib/src/rpc/dto/transaction_details.g.dart
+++ b/packages/solana/lib/src/rpc/dto/transaction_details.g.dart
@@ -8,9 +8,9 @@ part of 'transaction_details.dart';
 
 TransactionDetails _$TransactionDetailsFromJson(Map<String, dynamic> json) =>
     TransactionDetails(
-      slot: json['slot'] as int,
+      slot: (json['slot'] as num).toInt(),
       transaction: Transaction.fromJson(json['transaction']),
-      blockTime: json['blockTime'] as int?,
+      blockTime: (json['blockTime'] as num?)?.toInt(),
       meta: json['meta'] == null
           ? null
           : Meta.fromJson(json['meta'] as Map<String, dynamic>),

--- a/packages/solana/lib/src/rpc/dto/transaction_message_header.g.dart
+++ b/packages/solana/lib/src/rpc/dto/transaction_message_header.g.dart
@@ -9,9 +9,11 @@ part of 'transaction_message_header.dart';
 TransactionMessageHeader _$TransactionMessageHeaderFromJson(
         Map<String, dynamic> json) =>
     TransactionMessageHeader(
-      numRequiredSignatures: json['numRequiredSignatures'] as int,
-      numReadonlySignedAccounts: json['numReadonlySignedAccounts'] as int,
-      numReadonlyUnsignedAccounts: json['numReadonlyUnsignedAccounts'] as int,
+      numRequiredSignatures: (json['numRequiredSignatures'] as num).toInt(),
+      numReadonlySignedAccounts:
+          (json['numReadonlySignedAccounts'] as num).toInt(),
+      numReadonlyUnsignedAccounts:
+          (json['numReadonlyUnsignedAccounts'] as num).toInt(),
     );
 
 Map<String, dynamic> _$TransactionMessageHeaderToJson(

--- a/packages/solana/lib/src/rpc/dto/transaction_signature_information.g.dart
+++ b/packages/solana/lib/src/rpc/dto/transaction_signature_information.g.dart
@@ -10,10 +10,10 @@ TransactionSignatureInformation _$TransactionSignatureInformationFromJson(
         Map<String, dynamic> json) =>
     TransactionSignatureInformation(
       signature: json['signature'] as String,
-      slot: json['slot'] as int,
+      slot: (json['slot'] as num).toInt(),
       err: json['err'] as Map<String, dynamic>?,
       memo: json['memo'] as String?,
-      blockTime: json['blockTime'] as int?,
+      blockTime: (json['blockTime'] as num?)?.toInt(),
       confirmationStatus:
           $enumDecodeNullable(_$CommitmentEnumMap, json['confirmationStatus']),
     );

--- a/packages/solana/lib/src/rpc/dto/transaction_status.g.dart
+++ b/packages/solana/lib/src/rpc/dto/transaction_status.g.dart
@@ -13,7 +13,7 @@ TransactionStatus _$TransactionStatusFromJson(Map<String, dynamic> json) =>
       accounts: (json['accounts'] as List<dynamic>?)
           ?.map((e) => Account.fromJson(e as Map<String, dynamic>))
           .toList(),
-      unitsConsumed: json['unitsConsumed'] as int?,
+      unitsConsumed: (json['unitsConsumed'] as num?)?.toInt(),
       returnData: json['returnData'] == null
           ? null
           : ReturnData.fromJson(json['returnData'] as Map<String, dynamic>),

--- a/packages/solana/lib/src/rpc/dto/vote_account.g.dart
+++ b/packages/solana/lib/src/rpc/dto/vote_account.g.dart
@@ -9,10 +9,10 @@ part of 'vote_account.dart';
 VoteAccount _$VoteAccountFromJson(Map<String, dynamic> json) => VoteAccount(
       votePubkey: json['votePubkey'] as String,
       nodePubkey: json['nodePubkey'] as String,
-      activatedStake: json['activatedStake'] as int,
+      activatedStake: (json['activatedStake'] as num).toInt(),
       epochVoteAccount: json['epochVoteAccount'] as bool,
-      commission: json['commission'] as int,
-      lastVote: json['lastVote'] as int,
+      commission: (json['commission'] as num).toInt(),
+      lastVote: (json['lastVote'] as num).toInt(),
       epochCredits: (json['epochCredits'] as List<dynamic>)
           .map(EpochCredits.fromJson)
           .toList(),

--- a/packages/solana/lib/src/solana_pay/accounts/transaction_request.freezed.dart
+++ b/packages/solana/lib/src/solana_pay/accounts/transaction_request.freezed.dart
@@ -12,7 +12,7 @@ part of 'transaction_request.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 TransactionRequestInfo _$TransactionRequestInfoFromJson(
     Map<String, dynamic> json) {
@@ -24,8 +24,12 @@ mixin _$TransactionRequestInfo {
   String get label => throw _privateConstructorUsedError;
   String get icon => throw _privateConstructorUsedError;
 
+  /// Serializes this TransactionRequestInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TransactionRequestInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TransactionRequestInfoCopyWith<TransactionRequestInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -50,6 +54,8 @@ class _$TransactionRequestInfoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TransactionRequestInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -91,6 +97,8 @@ class __$$TransactionRequestInfoImplCopyWithImpl<$Res>
       $Res Function(_$TransactionRequestInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TransactionRequestInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -137,11 +145,13 @@ class _$TransactionRequestInfoImpl implements _TransactionRequestInfo {
             (identical(other.icon, icon) || other.icon == icon));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, label, icon);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TransactionRequestInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TransactionRequestInfoImplCopyWith<_$TransactionRequestInfoImpl>
@@ -168,8 +178,11 @@ abstract class _TransactionRequestInfo implements TransactionRequestInfo {
   String get label;
   @override
   String get icon;
+
+  /// Create a copy of TransactionRequestInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TransactionRequestInfoImplCopyWith<_$TransactionRequestInfoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -185,8 +198,12 @@ mixin _$TransactionRequestResponse {
   String? get message => throw _privateConstructorUsedError;
   String? get redirect => throw _privateConstructorUsedError;
 
+  /// Serializes this TransactionRequestResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TransactionRequestResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TransactionRequestResponseCopyWith<TransactionRequestResponse>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -212,6 +229,8 @@ class _$TransactionRequestResponseCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TransactionRequestResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -258,6 +277,8 @@ class __$$TransactionRequestResponseImplCopyWithImpl<$Res>
       $Res Function(_$TransactionRequestResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TransactionRequestResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -316,11 +337,13 @@ class _$TransactionRequestResponseImpl implements _TransactionRequestResponse {
                 other.redirect == redirect));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, transaction, message, redirect);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TransactionRequestResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TransactionRequestResponseImplCopyWith<_$TransactionRequestResponseImpl>
@@ -351,8 +374,11 @@ abstract class _TransactionRequestResponse
   String? get message;
   @override
   String? get redirect;
+
+  /// Create a copy of TransactionRequestResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TransactionRequestResponseImplCopyWith<_$TransactionRequestResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/solana_pay/solana_pay_request.freezed.dart
+++ b/packages/solana/lib/src/solana_pay/solana_pay_request.freezed.dart
@@ -12,7 +12,7 @@ part of 'solana_pay_request.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$SolanaPayRequest {
@@ -25,7 +25,9 @@ mixin _$SolanaPayRequest {
   String? get message => throw _privateConstructorUsedError;
   String? get memo => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SolanaPayRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SolanaPayRequestCopyWith<SolanaPayRequest> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -56,6 +58,8 @@ class _$SolanaPayRequestCopyWithImpl<$Res, $Val extends SolanaPayRequest>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SolanaPayRequest
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -126,6 +130,8 @@ class __$$SolanaPayRequestImplCopyWithImpl<$Res>
       $Res Function(_$SolanaPayRequestImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SolanaPayRequest
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -223,7 +229,9 @@ class _$SolanaPayRequestImpl extends _SolanaPayRequest {
   int get hashCode => Object.hash(runtimeType, recipient, amount, splToken,
       const DeepCollectionEquality().hash(reference), label, message, memo);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SolanaPayRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SolanaPayRequestImplCopyWith<_$SolanaPayRequestImpl> get copyWith =>
@@ -256,8 +264,11 @@ abstract class _SolanaPayRequest extends SolanaPayRequest {
   String? get message;
   @override
   String? get memo;
+
+  /// Create a copy of SolanaPayRequest
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SolanaPayRequestImplCopyWith<_$SolanaPayRequestImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/solana_pay/solana_transaction_request.freezed.dart
+++ b/packages/solana/lib/src/solana_pay/solana_transaction_request.freezed.dart
@@ -12,7 +12,7 @@ part of 'solana_transaction_request.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$SolanaTransactionRequest {
@@ -20,7 +20,9 @@ mixin _$SolanaTransactionRequest {
   String? get label => throw _privateConstructorUsedError;
   String? get message => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SolanaTransactionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SolanaTransactionRequestCopyWith<SolanaTransactionRequest> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -45,6 +47,8 @@ class _$SolanaTransactionRequestCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SolanaTransactionRequest
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -91,6 +95,8 @@ class __$$SolanaTransactionRequestImplCopyWithImpl<$Res>
       $Res Function(_$SolanaTransactionRequestImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SolanaTransactionRequest
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -147,7 +153,9 @@ class _$SolanaTransactionRequestImpl extends _SolanaTransactionRequest {
   @override
   int get hashCode => Object.hash(runtimeType, link, label, message);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SolanaTransactionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SolanaTransactionRequestImplCopyWith<_$SolanaTransactionRequestImpl>
@@ -168,8 +176,11 @@ abstract class _SolanaTransactionRequest extends SolanaTransactionRequest {
   String? get label;
   @override
   String? get message;
+
+  /// Create a copy of SolanaTransactionRequest
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SolanaTransactionRequestImplCopyWith<_$SolanaTransactionRequestImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/subscription_client/error_message.g.dart
+++ b/packages/solana/lib/src/subscription_client/error_message.g.dart
@@ -8,7 +8,7 @@ part of 'error_message.dart';
 
 ErrorMessage _$ErrorMessageFromJson(Map<String, dynamic> json) => ErrorMessage(
       error: SubscribeError.fromJson(json['error'] as Map<String, dynamic>),
-      id: json['id'] as int,
+      id: (json['id'] as num).toInt(),
     );
 
 Map<String, dynamic> _$ErrorMessageToJson(ErrorMessage instance) =>

--- a/packages/solana/lib/src/subscription_client/logs_filter.freezed.dart
+++ b/packages/solana/lib/src/subscription_client/logs_filter.freezed.dart
@@ -12,7 +12,7 @@ part of 'logs_filter.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$LogsFilter {
@@ -78,6 +78,9 @@ class _$LogsFilterCopyWithImpl<$Res, $Val extends LogsFilter>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of LogsFilter
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -94,6 +97,9 @@ class __$$LogsFilterAllImplCopyWithImpl<$Res>
   __$$LogsFilterAllImplCopyWithImpl(
       _$LogsFilterAllImpl _value, $Res Function(_$LogsFilterAllImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of LogsFilter
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -204,6 +210,9 @@ class __$$LosgFilterAllWithVotesImplCopyWithImpl<$Res>
       _$LosgFilterAllWithVotesImpl _value,
       $Res Function(_$LosgFilterAllWithVotesImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of LogsFilter
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -316,6 +325,8 @@ class __$$LogsFilterMentionsImplCopyWithImpl<$Res>
       $Res Function(_$LogsFilterMentionsImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LogsFilter
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -361,7 +372,9 @@ class _$LogsFilterMentionsImpl implements _LogsFilterMentions {
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_pubKeys));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LogsFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LogsFilterMentionsImplCopyWith<_$LogsFilterMentionsImpl> get copyWith =>
@@ -442,7 +455,10 @@ abstract class _LogsFilterMentions implements LogsFilter {
       _$LogsFilterMentionsImpl;
 
   List<String> get pubKeys;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LogsFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LogsFilterMentionsImplCopyWith<_$LogsFilterMentionsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/subscription_client/notification_context.g.dart
+++ b/packages/solana/lib/src/subscription_client/notification_context.g.dart
@@ -8,7 +8,7 @@ part of 'notification_context.dart';
 
 NotificationContext _$NotificationContextFromJson(Map<String, dynamic> json) =>
     NotificationContext(
-      slot: json['slot'] as int,
+      slot: (json['slot'] as num).toInt(),
     );
 
 Map<String, dynamic> _$NotificationContextToJson(

--- a/packages/solana/lib/src/subscription_client/notification_message.freezed.dart
+++ b/packages/solana/lib/src/subscription_client/notification_message.freezed.dart
@@ -12,7 +12,7 @@ part of 'notification_message.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 NotificationMessage _$NotificationMessageFromJson(Map<String, dynamic> json) {
   switch (json['method']) {
@@ -102,6 +102,8 @@ mixin _$NotificationMessage {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this NotificationMessage to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
 
@@ -121,6 +123,9 @@ class _$NotificationMessageCopyWithImpl<$Res, $Val extends NotificationMessage>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -140,6 +145,9 @@ class __$$UnsupportedNotificationImplCopyWithImpl<$Res>
       _$UnsupportedNotificationImpl _value,
       $Res Function(_$UnsupportedNotificationImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -167,7 +175,7 @@ class _$UnsupportedNotificationImpl extends _UnsupportedNotification {
             other is _$UnsupportedNotificationImpl);
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => runtimeType.hashCode;
 
@@ -296,6 +304,8 @@ class __$$AccountNotificationImplCopyWithImpl<$Res>
       $Res Function(_$AccountNotificationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -339,11 +349,13 @@ class _$AccountNotificationImpl extends AccountNotification {
             (identical(other.params, params) || other.params == params));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, params);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AccountNotificationImplCopyWith<_$AccountNotificationImpl> get copyWith =>
@@ -460,7 +472,10 @@ abstract class AccountNotification extends NotificationMessage {
       _$AccountNotificationImpl.fromJson;
 
   NotificationParams<Account> get params;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AccountNotificationImplCopyWith<_$AccountNotificationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -482,6 +497,8 @@ class __$$LogsNotificationImplCopyWithImpl<$Res>
       $Res Function(_$LogsNotificationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -525,11 +542,13 @@ class _$LogsNotificationImpl extends LogsNotification {
             (identical(other.params, params) || other.params == params));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, params);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LogsNotificationImplCopyWith<_$LogsNotificationImpl> get copyWith =>
@@ -646,7 +665,10 @@ abstract class LogsNotification extends NotificationMessage {
       _$LogsNotificationImpl.fromJson;
 
   NotificationParams<Logs> get params;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LogsNotificationImplCopyWith<_$LogsNotificationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -668,6 +690,8 @@ class __$$ProgramNotificationImplCopyWithImpl<$Res>
       $Res Function(_$ProgramNotificationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -711,11 +735,13 @@ class _$ProgramNotificationImpl extends ProgramNotification {
             (identical(other.params, params) || other.params == params));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, params);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ProgramNotificationImplCopyWith<_$ProgramNotificationImpl> get copyWith =>
@@ -832,7 +858,10 @@ abstract class ProgramNotification extends NotificationMessage {
       _$ProgramNotificationImpl.fromJson;
 
   NotificationParams<dynamic> get params;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ProgramNotificationImplCopyWith<_$ProgramNotificationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -855,6 +884,8 @@ class __$$SignatureNotificationImplCopyWithImpl<$Res>
       $Res Function(_$SignatureNotificationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -898,11 +929,13 @@ class _$SignatureNotificationImpl extends SignatureNotification {
             (identical(other.params, params) || other.params == params));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, params);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SignatureNotificationImplCopyWith<_$SignatureNotificationImpl>
@@ -1019,7 +1052,10 @@ abstract class SignatureNotification extends NotificationMessage {
       _$SignatureNotificationImpl.fromJson;
 
   NotificationParams<OptionalError> get params;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SignatureNotificationImplCopyWith<_$SignatureNotificationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1041,6 +1077,8 @@ class __$$SlotNotificationImplCopyWithImpl<$Res>
       $Res Function(_$SlotNotificationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1084,11 +1122,13 @@ class _$SlotNotificationImpl extends SlotNotification {
             (identical(other.params, params) || other.params == params));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, params);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SlotNotificationImplCopyWith<_$SlotNotificationImpl> get copyWith =>
@@ -1205,7 +1245,10 @@ abstract class SlotNotification extends NotificationMessage {
       _$SlotNotificationImpl.fromJson;
 
   NotificationParams<Slot> get params;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NotificationMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SlotNotificationImplCopyWith<_$SlotNotificationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/subscription_client/notification_params.g.dart
+++ b/packages/solana/lib/src/subscription_client/notification_params.g.dart
@@ -13,7 +13,7 @@ NotificationParams<T> _$NotificationParamsFromJson<T>(
     NotificationParams<T>(
       result: NotificationResult<T>.fromJson(
           json['result'] as Map<String, dynamic>, (value) => fromJsonT(value)),
-      subscription: json['subscription'] as int,
+      subscription: (json['subscription'] as num).toInt(),
     );
 
 Map<String, dynamic> _$NotificationParamsToJson<T>(

--- a/packages/solana/lib/src/subscription_client/subscribe_error.g.dart
+++ b/packages/solana/lib/src/subscription_client/subscribe_error.g.dart
@@ -8,7 +8,7 @@ part of 'subscribe_error.dart';
 
 SubscribeError _$SubscribeErrorFromJson(Map<String, dynamic> json) =>
     SubscribeError(
-      code: json['code'] as int,
+      code: (json['code'] as num).toInt(),
       message: json['message'] as String,
     );
 

--- a/packages/solana/lib/src/subscription_client/subscribed_message.g.dart
+++ b/packages/solana/lib/src/subscription_client/subscribed_message.g.dart
@@ -8,8 +8,8 @@ part of 'subscribed_message.dart';
 
 SubscribedMessage _$SubscribedMessageFromJson(Map<String, dynamic> json) =>
     SubscribedMessage(
-      result: json['result'] as int,
-      id: json['id'] as int,
+      result: (json['result'] as num).toInt(),
+      id: (json['id'] as num).toInt(),
     );
 
 Map<String, dynamic> _$SubscribedMessageToJson(SubscribedMessage instance) =>

--- a/packages/solana/lib/src/subscription_client/unsubscribed_message.g.dart
+++ b/packages/solana/lib/src/subscription_client/unsubscribed_message.g.dart
@@ -8,8 +8,8 @@ part of 'unsubscribed_message.dart';
 
 UnsubscribedMessage _$UnsubscribedMessageFromJson(Map<String, dynamic> json) =>
     UnsubscribedMessage(
-      result: json['result'] as int,
-      id: json['id'] as int,
+      result: (json['result'] as num).toInt(),
+      id: (json['id'] as num).toInt(),
     );
 
 Map<String, dynamic> _$UnsubscribedMessageToJson(

--- a/packages/solana/pubspec.yaml
+++ b/packages/solana/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   Provides convenient interface for the RPC methods.
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.2.0
 
 dependencies:
   bip39: ^1.0.6

--- a/packages/solana/pubspec.yaml
+++ b/packages/solana/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   collection: ^1.15.0
   convert: ^3.0.1
   cryptography: ^2.5.0
-  decimal: ^2.1.0
+  decimal: ">=2.1.0 <4.0.0"
   ed25519_hd_key: ^2.1.0
   freezed_annotation: ^2.0.0
   http: ^1.1.0

--- a/packages/solana/pubspec.yaml
+++ b/packages/solana/pubspec.yaml
@@ -29,5 +29,5 @@ dev_dependencies:
   json_serializable: ^6.0.0
   jsonrpc_client:
     path: ../jsonrpc_client
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
   test: ^1.17.11

--- a/packages/solana/pubspec.yaml
+++ b/packages/solana/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   Provides convenient interface for the RPC methods.
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   bip39: ^1.0.6

--- a/packages/solana/pubspec.yaml
+++ b/packages/solana/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   Provides convenient interface for the RPC methods.
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   bip39: ^1.0.6

--- a/packages/solana_mobile_client/example/pubspec.lock
+++ b/packages/solana_mobile_client/example/pubspec.lock
@@ -6,7 +6,7 @@ packages:
     description:
       name: _fe_analyzer_shared
       sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "80.0.0"
   analyzer:
@@ -14,7 +14,7 @@ packages:
     description:
       name: analyzer
       sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.3.0"
   args:
@@ -22,7 +22,7 @@ packages:
     description:
       name: args
       sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.0"
   async:
@@ -30,7 +30,7 @@ packages:
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
   bip39:
@@ -38,7 +38,7 @@ packages:
     description:
       name: bip39
       sha256: de1ee27ebe7d96b84bb3a04a4132a0a3007dcdd5ad27dd14aa87a29d97c45edc
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
   bloc:
@@ -46,7 +46,7 @@ packages:
     description:
       name: bloc
       sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.4"
   boolean_selector:
@@ -54,7 +54,7 @@ packages:
     description:
       name: boolean_selector
       sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   borsh_annotation:
@@ -69,7 +69,7 @@ packages:
     description:
       name: build
       sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
   build_config:
@@ -77,7 +77,7 @@ packages:
     description:
       name: build_config
       sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   build_daemon:
@@ -85,7 +85,7 @@ packages:
     description:
       name: build_daemon
       sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.4"
   build_resolvers:
@@ -93,7 +93,7 @@ packages:
     description:
       name: build_resolvers
       sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
   build_runner:
@@ -101,7 +101,7 @@ packages:
     description:
       name: build_runner
       sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.15"
   build_runner_core:
@@ -109,7 +109,7 @@ packages:
     description:
       name: build_runner_core
       sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.0.0"
   built_collection:
@@ -117,7 +117,7 @@ packages:
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
@@ -125,7 +125,7 @@ packages:
     description:
       name: built_value
       sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.9.3"
   characters:
@@ -133,7 +133,7 @@ packages:
     description:
       name: characters
       sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   checked_yaml:
@@ -141,7 +141,7 @@ packages:
     description:
       name: checked_yaml
       sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
   clock:
@@ -149,7 +149,7 @@ packages:
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   code_builder:
@@ -157,7 +157,7 @@ packages:
     description:
       name: code_builder
       sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.10.1"
   collection:
@@ -165,7 +165,7 @@ packages:
     description:
       name: collection
       sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.19.0"
   convert:
@@ -173,7 +173,7 @@ packages:
     description:
       name: convert
       sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
   crypto:
@@ -181,7 +181,7 @@ packages:
     description:
       name: crypto
       sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
   cryptography:
@@ -189,7 +189,7 @@ packages:
     description:
       name: cryptography
       sha256: d146b76d33d94548cf035233fbc2f4338c1242fa119013bead807d033fc4ae05
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
   cupertino_icons:
@@ -197,7 +197,7 @@ packages:
     description:
       name: cupertino_icons
       sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
   dart_style:
@@ -205,7 +205,7 @@ packages:
     description:
       name: dart_style
       sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   decimal:
@@ -213,7 +213,7 @@ packages:
     description:
       name: decimal
       sha256: "28239b8b929c1bd8618702e6dbc96e2618cf99770bbe9cb040d6cf56a11e4ec3"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   ed25519_hd_key:
@@ -221,7 +221,7 @@ packages:
     description:
       name: ed25519_hd_key
       sha256: "31e191ec97492873067e46dc9cc0c7d55170559c83a478400feffa0627acaccf"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   fake_async:
@@ -229,7 +229,7 @@ packages:
     description:
       name: fake_async
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
@@ -237,7 +237,7 @@ packages:
     description:
       name: ffi
       sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   file:
@@ -245,7 +245,7 @@ packages:
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
   fixnum:
@@ -253,7 +253,7 @@ packages:
     description:
       name: fixnum
       sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   flutter:
@@ -266,7 +266,7 @@ packages:
     description:
       name: flutter_bloc
       sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.6"
   flutter_test:
@@ -279,7 +279,7 @@ packages:
     description:
       name: freezed
       sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.8"
   freezed_annotation:
@@ -287,7 +287,7 @@ packages:
     description:
       name: freezed_annotation
       sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
   frontend_server_client:
@@ -295,7 +295,7 @@ packages:
     description:
       name: frontend_server_client
       sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   glob:
@@ -303,7 +303,7 @@ packages:
     description:
       name: glob
       sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   graphs:
@@ -311,7 +311,7 @@ packages:
     description:
       name: graphs
       sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   hex:
@@ -319,7 +319,7 @@ packages:
     description:
       name: hex
       sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   http:
@@ -327,7 +327,7 @@ packages:
     description:
       name: http
       sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   http_multi_server:
@@ -335,7 +335,7 @@ packages:
     description:
       name: http_multi_server
       sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
   http_parser:
@@ -343,7 +343,7 @@ packages:
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
   intl:
@@ -351,7 +351,7 @@ packages:
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.20.2"
   io:
@@ -359,7 +359,7 @@ packages:
     description:
       name: io
       sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   js:
@@ -367,7 +367,7 @@ packages:
     description:
       name: js
       sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
   json_annotation:
@@ -375,7 +375,7 @@ packages:
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
   leak_tracker:
@@ -383,7 +383,7 @@ packages:
     description:
       name: leak_tracker
       sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "10.0.7"
   leak_tracker_flutter_testing:
@@ -391,7 +391,7 @@ packages:
     description:
       name: leak_tracker_flutter_testing
       sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.8"
   leak_tracker_testing:
@@ -399,7 +399,7 @@ packages:
     description:
       name: leak_tracker_testing
       sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   logging:
@@ -407,7 +407,7 @@ packages:
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   matcher:
@@ -415,7 +415,7 @@ packages:
     description:
       name: matcher
       sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.16+1"
   material_color_utilities:
@@ -423,7 +423,7 @@ packages:
     description:
       name: material_color_utilities
       sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
   meta:
@@ -431,7 +431,7 @@ packages:
     description:
       name: meta
       sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
   mews_pedantic:
@@ -439,7 +439,7 @@ packages:
     description:
       name: mews_pedantic
       sha256: a2d2c5c89e03eb40ed70918f47c1fa7216059384837f9d9d1cd56f5df305cc53
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.27.0"
   mime:
@@ -447,7 +447,7 @@ packages:
     description:
       name: mime
       sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   nested:
@@ -455,7 +455,7 @@ packages:
     description:
       name: nested
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   package_config:
@@ -463,7 +463,7 @@ packages:
     description:
       name: package_config
       sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   path:
@@ -471,7 +471,7 @@ packages:
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
   pinenacl:
@@ -479,7 +479,7 @@ packages:
     description:
       name: pinenacl
       sha256: "57e907beaacbc3c024a098910b6240758e899674de07d6949a67b52fd984cbdf"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
   plugin_platform_interface:
@@ -487,7 +487,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
   pointycastle:
@@ -495,7 +495,7 @@ packages:
     description:
       name: pointycastle
       sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.9.1"
   pool:
@@ -503,7 +503,7 @@ packages:
     description:
       name: pool
       sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   provider:
@@ -511,7 +511,7 @@ packages:
     description:
       name: provider
       sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
   pub_semver:
@@ -519,7 +519,7 @@ packages:
     description:
       name: pub_semver
       sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.5"
   pubspec_parse:
@@ -527,7 +527,7 @@ packages:
     description:
       name: pubspec_parse
       sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   rational:
@@ -535,7 +535,7 @@ packages:
     description:
       name: rational
       sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   shelf:
@@ -543,7 +543,7 @@ packages:
     description:
       name: shelf
       sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
   shelf_web_socket:
@@ -551,7 +551,7 @@ packages:
     description:
       name: shelf_web_socket
       sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   sky_engine:
@@ -578,7 +578,7 @@ packages:
     description:
       name: source_gen
       sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   source_span:
@@ -586,7 +586,7 @@ packages:
     description:
       name: source_span
       sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
   stack_trace:
@@ -594,7 +594,7 @@ packages:
     description:
       name: stack_trace
       sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
   stream_channel:
@@ -602,7 +602,7 @@ packages:
     description:
       name: stream_channel
       sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   stream_transform:
@@ -610,7 +610,7 @@ packages:
     description:
       name: stream_transform
       sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   string_scanner:
@@ -618,7 +618,7 @@ packages:
     description:
       name: string_scanner
       sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   term_glyph:
@@ -626,7 +626,7 @@ packages:
     description:
       name: term_glyph
       sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
@@ -634,7 +634,7 @@ packages:
     description:
       name: test_api
       sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.3"
   timing:
@@ -642,7 +642,7 @@ packages:
     description:
       name: timing
       sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   typed_data:
@@ -650,7 +650,7 @@ packages:
     description:
       name: typed_data
       sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   vector_math:
@@ -658,7 +658,7 @@ packages:
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   vm_service:
@@ -666,7 +666,7 @@ packages:
     description:
       name: vm_service
       sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "14.3.0"
   watcher:
@@ -674,7 +674,7 @@ packages:
     description:
       name: watcher
       sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   web:
@@ -682,7 +682,7 @@ packages:
     description:
       name: web
       sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   web_socket:
@@ -690,7 +690,7 @@ packages:
     description:
       name: web_socket
       sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.6"
   web_socket_channel:
@@ -698,7 +698,7 @@ packages:
     description:
       name: web_socket_channel
       sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   yaml:
@@ -706,7 +706,7 @@ packages:
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
 sdks:

--- a/packages/solana_mobile_client/example/pubspec.lock
+++ b/packages/solana_mobile_client/example/pubspec.lock
@@ -5,32 +5,32 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0c80aeab9bc807ab10022cd3b2f4cf2ecdf231949dc1ddd9442406a003f19201"
-      url: "https://pub.dev"
+      sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "52.0.0"
+    version: "80.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: cd8ee83568a77f3ae6b913a36093a1c9b1264e7cb7f834d9ddd2311dade9c1f4
-      url: "https://pub.dev"
+      sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "5.4.0"
+    version: "7.3.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
-      url: "https://pub.dev"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.2"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.11.0"
   bip39:
@@ -38,217 +38,224 @@ packages:
     description:
       name: bip39
       sha256: de1ee27ebe7d96b84bb3a04a4132a0a3007dcdd5ad27dd14aa87a29d97c45edc
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.6"
   bloc:
     dependency: transitive
     description:
       name: bloc
-      sha256: bd4f8027bfa60d96c8046dec5ce74c463b2c918dce1b0d36593575995344534a
-      url: "https://pub.dev"
+      sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "8.1.0"
+    version: "8.1.4"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.1"
   borsh_annotation:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: borsh_annotation
-      sha256: "4a226cf8b7a165ecf8020c0c8d366b2728167fd102ef9b9e89d94d86f89ac57b"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../borsh_annotation"
+      relative: true
+    source: path
     version: "0.3.1+5"
   build:
     dependency: transitive
     description:
       name: build
-      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
-      url: "https://pub.dev"
+      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
-      url: "https://pub.dev"
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
-      url: "https://pub.dev"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "687cf90a3951affac1bd5f9ecb5e3e90b60487f3d9cdc359bb310f8876bb02a6"
-      url: "https://pub.dev"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.0.10"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
-      url: "https://pub.dev"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
-      url: "https://pub.dev"
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "7.2.7"
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      sha256: "169565c8ad06adb760c3645bf71f00bff161b00002cace266cad42c5d22a7725"
-      url: "https://pub.dev"
+      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "8.4.3"
+    version: "8.9.3"
   characters:
     dependency: transitive
     description:
       name: characters
       sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
-      url: "https://pub.dev"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   clock:
     dependency: transitive
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "0d43dd1288fd145de1ecc9a3948ad4a6d5a82f0a14c4fdd0892260787d975cbe"
-      url: "https://pub.dev"
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.4.0"
+    version: "4.10.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
-      url: "https://pub.dev"
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
-      url: "https://pub.dev"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
-      url: "https://pub.dev"
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.6"
   cryptography:
     dependency: transitive
     description:
       name: cryptography
-      sha256: df156c5109286340817d21fa7b62f9140f17915077127dd70f8bd7a2a0997a35
-      url: "https://pub.dev"
+      sha256: d146b76d33d94548cf035233fbc2f4338c1242fa119013bead807d033fc4ae05
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
-      url: "https://pub.dev"
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.8"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7a03456c3490394c8e7665890333e91ae8a49be43542b616e414449ac358acd4"
-      url: "https://pub.dev"
+      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.4"
+    version: "3.0.1"
   decimal:
     dependency: transitive
     description:
       name: decimal
-      sha256: eece91944f523657c75a3a008a90ec7f7eb3986191153a78570c7d0ac8ef3d01
-      url: "https://pub.dev"
+      sha256: "28239b8b929c1bd8618702e6dbc96e2618cf99770bbe9cb040d6cf56a11e4ec3"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.2"
+    version: "3.2.1"
   ed25519_hd_key:
     dependency: transitive
     description:
       name: ed25519_hd_key
-      sha256: "326608234e986ea826a5db4cf4cd6826058d860875a3fff7926c0725fe1a604d"
-      url: "https://pub.dev"
+      sha256: "31e191ec97492873067e46dc9cc0c7d55170559c83a478400feffa0627acaccf"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
-      url: "https://pub.dev"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
-      url: "https://pub.dev"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -258,10 +265,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: "890c51c8007f0182360e523518a0c732efb89876cb4669307af7efada5b55557"
-      url: "https://pub.dev"
+      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "8.1.1"
+    version: "8.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -271,136 +278,144 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "4179d41127bc7a67dc3f58ceec1d22f1cdf10470653cb86eda2a63f81b4920c7"
-      url: "https://pub.dev"
+      sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.0"
+    version: "2.5.8"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
-      url: "https://pub.dev"
+      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.4"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
-      url: "https://pub.dev"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
-      url: "https://pub.dev"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
-      url: "https://pub.dev"
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.2"
   hex:
     dependency: transitive
     description:
       name: hex
       sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.2.0"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
-      url: "https://pub.dev"
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0"
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
-      url: "https://pub.dev"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.dev"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
-      url: "https://pub.dev"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   js:
     dependency: transitive
     description:
       name: js
       sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
-      url: "https://pub.dev"
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
-      url: "https://pub.dev"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
-      url: "https://pub.dev"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
       sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
-      url: "https://pub.dev"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.1"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.12.16+1"
   material_color_utilities:
@@ -408,7 +423,7 @@ packages:
     description:
       name: material_color_utilities
       sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.11.1"
   meta:
@@ -416,142 +431,141 @@ packages:
     description:
       name: meta
       sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.15.0"
   mews_pedantic:
     dependency: "direct dev"
     description:
       name: mews_pedantic
-      sha256: e05e23939d52f7de00bcef2265f5edc3dfbee1f2bd513ba1f03500c9ab116f16
-      url: "https://pub.dev"
+      sha256: a2d2c5c89e03eb40ed70918f47c1fa7216059384837f9d9d1cd56f5df305cc53
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.26.0"
+    version: "0.27.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
-      url: "https://pub.dev"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   nested:
     dependency: transitive
     description:
       name: nested
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
-      url: "https://pub.dev"
+      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   path:
     dependency: transitive
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.9.0"
   pinenacl:
     dependency: transitive
     description:
       name: pinenacl
-      sha256: e5fb0bce1717b7f136f35ee98b5c02b3e6383211f8a77ca882fa7812232a07b9
-      url: "https://pub.dev"
+      sha256: "57e907beaacbc3c024a098910b6240758e899674de07d6949a67b52fd984cbdf"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.3.4"
+    version: "0.6.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: dbf0f707c78beedc9200146ad3cb0ab4d5da13c246336987be6940f026500d3a
-      url: "https://pub.dev"
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.8"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
-      url: "https://pub.dev"
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.6.2"
+    version: "3.9.1"
   pool:
     dependency: transitive
     description:
       name: pool
       sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.5.1"
   provider:
     dependency: transitive
     description:
       name: provider
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
-      url: "https://pub.dev"
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.2"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
-      url: "https://pub.dev"
+      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "75f6614d6dde2dc68948dffbaa4fe5dae32cd700eb9fb763fe11dfb45a3c4d0a"
-      url: "https://pub.dev"
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.1"
+    version: "1.5.0"
   rational:
     dependency: transitive
     description:
       name: rational
-      sha256: ba58e9e18df9abde280e8b10051e4bce85091e41e8e7e411b6cde2e738d357cf
-      url: "https://pub.dev"
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
-      url: "https://pub.dev"
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
-      url: "https://pub.dev"
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.3"
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   solana:
     dependency: "direct main"
     description:
-      name: solana
-      sha256: "3f8c9ad84af6fbce1e5d76ab67b17c9ec944185235a6032b578ecab0b1f59ee3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.31.0+1"
+      path: "../../solana"
+      relative: true
+    source: path
+    version: "0.31.2"
   solana_mobile_client:
     dependency: "direct main"
     description:
@@ -563,122 +577,138 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "2d79738b6bbf38a43920e2b8d189e9a3ce6cc201f4b8fc76be5e4fe377b1c38d"
-      url: "https://pub.dev"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.6"
+    version: "2.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
       sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
-      url: "https://pub.dev"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
-      url: "https://pub.dev"
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
-      url: "https://pub.dev"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
-      url: "https://pub.dev"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   timing:
     dependency: transitive
     description:
       name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
-      url: "https://pub.dev"
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
-      url: "https://pub.dev"
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
-      url: "https://pub.dev"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
-      url: "https://pub.dev"
+      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "1.1.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
-      url: "https://pub.dev"
+      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.2"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
-      url: "https://pub.dev"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/solana_mobile_client/example/pubspec.yaml
+++ b/packages/solana_mobile_client/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the solana_mobile_client plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/packages/solana_mobile_client/example/pubspec.yaml
+++ b/packages/solana_mobile_client/example/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^2.1.0+1
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
 
 flutter:
   uses-material-design: true

--- a/packages/solana_mobile_client/example/pubspec.yaml
+++ b/packages/solana_mobile_client/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the solana_mobile_client plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/packages/solana_mobile_client/example/pubspec.yaml
+++ b/packages/solana_mobile_client/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the solana_mobile_client plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/packages/solana_mobile_client/pubspec.yaml
+++ b/packages/solana_mobile_client/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/espresso-cash/espresso-cash-public/tree/master/pa
 issue_tracker: https://github.com/espresso-cash/espresso-cash-public/issues
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=2.5.0"
 
 dependencies:

--- a/packages/solana_mobile_client/pubspec.yaml
+++ b/packages/solana_mobile_client/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
     sdk: flutter
   freezed: ^2.1.0+1
   json_serializable: ^6.3.1
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
   pigeon: ^7.1.1
 
 flutter:

--- a/packages/solana_mobile_client/pubspec.yaml
+++ b/packages/solana_mobile_client/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/espresso-cash/espresso-cash-public/tree/master/pa
 issue_tracker: https://github.com/espresso-cash/espresso-cash-public/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
   flutter: ">=3.10.0"
 
 dependencies:

--- a/packages/solana_mobile_client/pubspec.yaml
+++ b/packages/solana_mobile_client/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/espresso-cash/espresso-cash-public/tree/master/pa
 issue_tracker: https://github.com/espresso-cash/espresso-cash-public/issues
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:

--- a/packages/solana_mobile_wallet/example/pubspec.lock
+++ b/packages/solana_mobile_wallet/example/pubspec.lock
@@ -5,32 +5,32 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
-      url: "https://pub.dev"
+      sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "61.0.0"
+    version: "80.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
-      url: "https://pub.dev"
+      sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "5.13.0"
+    version: "7.3.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
-      url: "https://pub.dev"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.2"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.11.0"
   bip39:
@@ -38,225 +38,224 @@ packages:
     description:
       name: bip39
       sha256: de1ee27ebe7d96b84bb3a04a4132a0a3007dcdd5ad27dd14aa87a29d97c45edc
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.6"
   bloc:
     dependency: transitive
     description:
       name: bloc
-      sha256: bd4f8027bfa60d96c8046dec5ce74c463b2c918dce1b0d36593575995344534a
-      url: "https://pub.dev"
+      sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "8.1.0"
+    version: "8.1.4"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.1"
   borsh_annotation:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: borsh_annotation
-      sha256: "4a226cf8b7a165ecf8020c0c8d366b2728167fd102ef9b9e89d94d86f89ac57b"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../borsh_annotation"
+      relative: true
+    source: path
     version: "0.3.1+5"
   build:
     dependency: transitive
     description:
       name: build
-      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
-      url: "https://pub.dev"
+      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
-      url: "https://pub.dev"
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
-      url: "https://pub.dev"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "687cf90a3951affac1bd5f9ecb5e3e90b60487f3d9cdc359bb310f8876bb02a6"
-      url: "https://pub.dev"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.0.10"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
-      url: "https://pub.dev"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
-      url: "https://pub.dev"
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "7.2.7"
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      sha256: "169565c8ad06adb760c3645bf71f00bff161b00002cace266cad42c5d22a7725"
-      url: "https://pub.dev"
+      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "8.4.3"
+    version: "8.9.3"
   characters:
     dependency: transitive
     description:
       name: characters
       sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
-      url: "https://pub.dev"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   clock:
     dependency: transitive
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
-      url: "https://pub.dev"
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.10.0"
+    version: "4.10.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
-      url: "https://pub.dev"
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
-      url: "https://pub.dev"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
-      url: "https://pub.dev"
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.6"
   cryptography:
     dependency: transitive
     description:
       name: cryptography
-      sha256: df156c5109286340817d21fa7b62f9140f17915077127dd70f8bd7a2a0997a35
-      url: "https://pub.dev"
+      sha256: d146b76d33d94548cf035233fbc2f4338c1242fa119013bead807d033fc4ae05
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
-      url: "https://pub.dev"
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.8"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7a03456c3490394c8e7665890333e91ae8a49be43542b616e414449ac358acd4"
-      url: "https://pub.dev"
+      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.4"
+    version: "3.0.1"
   decimal:
     dependency: transitive
     description:
       name: decimal
-      sha256: eece91944f523657c75a3a008a90ec7f7eb3986191153a78570c7d0ac8ef3d01
-      url: "https://pub.dev"
+      sha256: "28239b8b929c1bd8618702e6dbc96e2618cf99770bbe9cb040d6cf56a11e4ec3"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.2"
+    version: "3.2.1"
   ed25519_hd_key:
     dependency: transitive
     description:
       name: ed25519_hd_key
-      sha256: "326608234e986ea826a5db4cf4cd6826058d860875a3fff7926c0725fe1a604d"
-      url: "https://pub.dev"
+      sha256: "31e191ec97492873067e46dc9cc0c7d55170559c83a478400feffa0627acaccf"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
-      url: "https://pub.dev"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
-      url: "https://pub.dev"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
-      url: "https://pub.dev"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -266,10 +265,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: "890c51c8007f0182360e523518a0c732efb89876cb4669307af7efada5b55557"
-      url: "https://pub.dev"
+      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "8.1.1"
+    version: "8.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -284,136 +283,144 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "4179d41127bc7a67dc3f58ceec1d22f1cdf10470653cb86eda2a63f81b4920c7"
-      url: "https://pub.dev"
+      sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.0"
+    version: "2.5.8"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
-      url: "https://pub.dev"
+      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.4"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
-      url: "https://pub.dev"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
-      url: "https://pub.dev"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
-      url: "https://pub.dev"
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.2"
   hex:
     dependency: transitive
     description:
       name: hex
       sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.2.0"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
-      url: "https://pub.dev"
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0"
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
-      url: "https://pub.dev"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.dev"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
-      url: "https://pub.dev"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   js:
     dependency: transitive
     description:
       name: js
       sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
-      url: "https://pub.dev"
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
-      url: "https://pub.dev"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
-      url: "https://pub.dev"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
       sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
-      url: "https://pub.dev"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.1"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.12.16+1"
   material_color_utilities:
@@ -421,7 +428,7 @@ packages:
     description:
       name: material_color_utilities
       sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.11.1"
   meta:
@@ -429,246 +436,237 @@ packages:
     description:
       name: meta
       sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.15.0"
   mews_pedantic:
     dependency: "direct dev"
     description:
       name: mews_pedantic
-      sha256: e05e23939d52f7de00bcef2265f5edc3dfbee1f2bd513ba1f03500c9ab116f16
-      url: "https://pub.dev"
+      sha256: a2d2c5c89e03eb40ed70918f47c1fa7216059384837f9d9d1cd56f5df305cc53
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.26.0"
+    version: "0.27.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
-      url: "https://pub.dev"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   mockito:
     dependency: transitive
     description:
       name: mockito
-      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
-      url: "https://pub.dev"
+      sha256: f99d8d072e249f719a5531735d146d8cf04c580d93920b04de75bef6dfb2daf6
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "5.4.4"
+    version: "5.4.5"
   nested:
     dependency: transitive
     description:
       name: nested
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
-      url: "https://pub.dev"
+      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   path:
     dependency: transitive
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.9.0"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: ab0987bf95bc591da42dffb38c77398fc43309f0b9b894dcc5d6f40c4b26c379
-      url: "https://pub.dev"
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.7"
+    version: "2.2.1"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: f0abc8ebd7253741f05488b4813d936b4d07c6bae3e86148a09e342ee4b08e76
-      url: "https://pub.dev"
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.2"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: bcabbe399d4042b8ee687e17548d5d3f527255253b4a639f5f8d2094a9c2b45c
-      url: "https://pub.dev"
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.3"
+    version: "2.3.0"
   pinenacl:
     dependency: transitive
     description:
       name: pinenacl
-      sha256: e5fb0bce1717b7f136f35ee98b5c02b3e6383211f8a77ca882fa7812232a07b9
-      url: "https://pub.dev"
+      sha256: "57e907beaacbc3c024a098910b6240758e899674de07d6949a67b52fd984cbdf"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.3.4"
+    version: "0.6.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
-      url: "https://pub.dev"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: dbf0f707c78beedc9200146ad3cb0ab4d5da13c246336987be6940f026500d3a
-      url: "https://pub.dev"
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.8"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
-      url: "https://pub.dev"
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.6.2"
+    version: "3.9.1"
   pool:
     dependency: transitive
     description:
       name: pool
       sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.5.1"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.4"
   provider:
     dependency: transitive
     description:
       name: provider
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
-      url: "https://pub.dev"
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.2"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
-      url: "https://pub.dev"
+      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "75f6614d6dde2dc68948dffbaa4fe5dae32cd700eb9fb763fe11dfb45a3c4d0a"
-      url: "https://pub.dev"
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.1"
+    version: "1.5.0"
   rational:
     dependency: transitive
     description:
       name: rational
-      sha256: ba58e9e18df9abde280e8b10051e4bce85091e41e8e7e411b6cde2e738d357cf
-      url: "https://pub.dev"
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "5949029e70abe87f75cfe59d17bf5c397619c4b74a099b10116baeb34786fad9"
-      url: "https://pub.dev"
+      sha256: "846849e3e9b68f3ef4b60c60cf4b3e02e9321bc7f4d8c4692cf87ffa82fc8a3a"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.0.17"
+    version: "2.5.2"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "955e9736a12ba776bdd261cf030232b30eadfcd9c79b32a3250dd4a494e8c8f7"
-      url: "https://pub.dev"
+      sha256: ea86be7b7114f9e94fddfbb52649e59a03d6627ccd2387ebddcd6624719e9f16
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.0.15"
+    version: "2.4.5"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "1ffa239043ab8baf881ec3094a3c767af9d10399b2839020b9e4d44c0bb23951"
-      url: "https://pub.dev"
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.2"
+    version: "2.5.4"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      sha256: f8ea038aa6da37090093974ebdcf4397010605fd2ff65c37a66f9d28394cb874
-      url: "https://pub.dev"
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.3"
+    version: "2.4.1"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: da9431745ede5ece47bc26d5d73a9d3c6936ef6945c101a5aca46f62e52c1cf3
-      url: "https://pub.dev"
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0"
+    version: "2.4.1"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: a4b5bc37fe1b368bbc81f953197d55e12f49d0296e7e412dfe2d2d77d6929958
-      url: "https://pub.dev"
+      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.0.4"
+    version: "2.4.2"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      sha256: "5eaf05ae77658d3521d0e993ede1af962d4b326cd2153d312df716dc250f00c9"
-      url: "https://pub.dev"
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.3"
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
-      url: "https://pub.dev"
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
-      url: "https://pub.dev"
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.3"
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   solana:
     dependency: "direct main"
     description:
-      name: solana
-      sha256: "3f8c9ad84af6fbce1e5d76ab67b17c9ec944185235a6032b578ecab0b1f59ee3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.31.0+1"
+      path: "../../solana"
+      relative: true
+    source: path
+    version: "0.31.2"
   solana_mobile_wallet:
     dependency: "direct main"
     description:
@@ -680,138 +678,146 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "2d79738b6bbf38a43920e2b8d189e9a3ce6cc201f4b8fc76be5e4fe377b1c38d"
-      url: "https://pub.dev"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.6"
+    version: "2.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
       sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
-      url: "https://pub.dev"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
-      url: "https://pub.dev"
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
-      url: "https://pub.dev"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
-      url: "https://pub.dev"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   timing:
     dependency: transitive
     description:
       name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
-      url: "https://pub.dev"
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
-      url: "https://pub.dev"
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
-      url: "https://pub.dev"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
-      url: "https://pub.dev"
+      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "1.1.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
-      url: "https://pub.dev"
+      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.3.0"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+    version: "3.0.2"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: bd512f03919aac5f1313eb8249f223bacf4927031bf60b02601f81f687689e86
-      url: "https://pub.dev"
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.2.0+3"
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
-      url: "https://pub.dev"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.6.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/packages/solana_mobile_wallet/example/pubspec.lock
+++ b/packages/solana_mobile_wallet/example/pubspec.lock
@@ -6,7 +6,7 @@ packages:
     description:
       name: _fe_analyzer_shared
       sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "80.0.0"
   analyzer:
@@ -14,7 +14,7 @@ packages:
     description:
       name: analyzer
       sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.3.0"
   args:
@@ -22,7 +22,7 @@ packages:
     description:
       name: args
       sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.0"
   async:
@@ -30,7 +30,7 @@ packages:
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
   bip39:
@@ -38,7 +38,7 @@ packages:
     description:
       name: bip39
       sha256: de1ee27ebe7d96b84bb3a04a4132a0a3007dcdd5ad27dd14aa87a29d97c45edc
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
   bloc:
@@ -46,7 +46,7 @@ packages:
     description:
       name: bloc
       sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.4"
   boolean_selector:
@@ -54,7 +54,7 @@ packages:
     description:
       name: boolean_selector
       sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   borsh_annotation:
@@ -69,7 +69,7 @@ packages:
     description:
       name: build
       sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
   build_config:
@@ -77,7 +77,7 @@ packages:
     description:
       name: build_config
       sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   build_daemon:
@@ -85,7 +85,7 @@ packages:
     description:
       name: build_daemon
       sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.4"
   build_resolvers:
@@ -93,7 +93,7 @@ packages:
     description:
       name: build_resolvers
       sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
   build_runner:
@@ -101,7 +101,7 @@ packages:
     description:
       name: build_runner
       sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.15"
   build_runner_core:
@@ -109,7 +109,7 @@ packages:
     description:
       name: build_runner_core
       sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.0.0"
   built_collection:
@@ -117,7 +117,7 @@ packages:
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
@@ -125,7 +125,7 @@ packages:
     description:
       name: built_value
       sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.9.3"
   characters:
@@ -133,7 +133,7 @@ packages:
     description:
       name: characters
       sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   checked_yaml:
@@ -141,7 +141,7 @@ packages:
     description:
       name: checked_yaml
       sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
   clock:
@@ -149,7 +149,7 @@ packages:
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   code_builder:
@@ -157,7 +157,7 @@ packages:
     description:
       name: code_builder
       sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.10.1"
   collection:
@@ -165,7 +165,7 @@ packages:
     description:
       name: collection
       sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.19.0"
   convert:
@@ -173,7 +173,7 @@ packages:
     description:
       name: convert
       sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
   crypto:
@@ -181,7 +181,7 @@ packages:
     description:
       name: crypto
       sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
   cryptography:
@@ -189,7 +189,7 @@ packages:
     description:
       name: cryptography
       sha256: d146b76d33d94548cf035233fbc2f4338c1242fa119013bead807d033fc4ae05
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
   cupertino_icons:
@@ -197,7 +197,7 @@ packages:
     description:
       name: cupertino_icons
       sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
   dart_style:
@@ -205,7 +205,7 @@ packages:
     description:
       name: dart_style
       sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   decimal:
@@ -213,7 +213,7 @@ packages:
     description:
       name: decimal
       sha256: "28239b8b929c1bd8618702e6dbc96e2618cf99770bbe9cb040d6cf56a11e4ec3"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   ed25519_hd_key:
@@ -221,7 +221,7 @@ packages:
     description:
       name: ed25519_hd_key
       sha256: "31e191ec97492873067e46dc9cc0c7d55170559c83a478400feffa0627acaccf"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   fake_async:
@@ -229,7 +229,7 @@ packages:
     description:
       name: fake_async
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
@@ -237,7 +237,7 @@ packages:
     description:
       name: ffi
       sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   file:
@@ -245,7 +245,7 @@ packages:
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
   fixnum:
@@ -253,7 +253,7 @@ packages:
     description:
       name: fixnum
       sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   flutter:
@@ -266,7 +266,7 @@ packages:
     description:
       name: flutter_bloc
       sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.6"
   flutter_test:
@@ -284,7 +284,7 @@ packages:
     description:
       name: freezed
       sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.8"
   freezed_annotation:
@@ -292,7 +292,7 @@ packages:
     description:
       name: freezed_annotation
       sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
   frontend_server_client:
@@ -300,7 +300,7 @@ packages:
     description:
       name: frontend_server_client
       sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   glob:
@@ -308,7 +308,7 @@ packages:
     description:
       name: glob
       sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   graphs:
@@ -316,7 +316,7 @@ packages:
     description:
       name: graphs
       sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   hex:
@@ -324,7 +324,7 @@ packages:
     description:
       name: hex
       sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   http:
@@ -332,7 +332,7 @@ packages:
     description:
       name: http
       sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   http_multi_server:
@@ -340,7 +340,7 @@ packages:
     description:
       name: http_multi_server
       sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
   http_parser:
@@ -348,7 +348,7 @@ packages:
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
   intl:
@@ -356,7 +356,7 @@ packages:
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.20.2"
   io:
@@ -364,7 +364,7 @@ packages:
     description:
       name: io
       sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   js:
@@ -372,7 +372,7 @@ packages:
     description:
       name: js
       sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
   json_annotation:
@@ -380,7 +380,7 @@ packages:
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
   leak_tracker:
@@ -388,7 +388,7 @@ packages:
     description:
       name: leak_tracker
       sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "10.0.7"
   leak_tracker_flutter_testing:
@@ -396,7 +396,7 @@ packages:
     description:
       name: leak_tracker_flutter_testing
       sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.8"
   leak_tracker_testing:
@@ -404,7 +404,7 @@ packages:
     description:
       name: leak_tracker_testing
       sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   logging:
@@ -412,7 +412,7 @@ packages:
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   matcher:
@@ -420,7 +420,7 @@ packages:
     description:
       name: matcher
       sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.16+1"
   material_color_utilities:
@@ -428,7 +428,7 @@ packages:
     description:
       name: material_color_utilities
       sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
   meta:
@@ -436,7 +436,7 @@ packages:
     description:
       name: meta
       sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
   mews_pedantic:
@@ -444,7 +444,7 @@ packages:
     description:
       name: mews_pedantic
       sha256: a2d2c5c89e03eb40ed70918f47c1fa7216059384837f9d9d1cd56f5df305cc53
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.27.0"
   mime:
@@ -452,7 +452,7 @@ packages:
     description:
       name: mime
       sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   mockito:
@@ -460,7 +460,7 @@ packages:
     description:
       name: mockito
       sha256: f99d8d072e249f719a5531735d146d8cf04c580d93920b04de75bef6dfb2daf6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.4.5"
   nested:
@@ -468,7 +468,7 @@ packages:
     description:
       name: nested
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   package_config:
@@ -476,7 +476,7 @@ packages:
     description:
       name: package_config
       sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   path:
@@ -484,7 +484,7 @@ packages:
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
   path_provider_linux:
@@ -492,7 +492,7 @@ packages:
     description:
       name: path_provider_linux
       sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
@@ -500,7 +500,7 @@ packages:
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   path_provider_windows:
@@ -508,7 +508,7 @@ packages:
     description:
       name: path_provider_windows
       sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   pinenacl:
@@ -516,7 +516,7 @@ packages:
     description:
       name: pinenacl
       sha256: "57e907beaacbc3c024a098910b6240758e899674de07d6949a67b52fd984cbdf"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
   platform:
@@ -524,7 +524,7 @@ packages:
     description:
       name: platform
       sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
@@ -532,7 +532,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
   pointycastle:
@@ -540,7 +540,7 @@ packages:
     description:
       name: pointycastle
       sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.9.1"
   pool:
@@ -548,7 +548,7 @@ packages:
     description:
       name: pool
       sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   provider:
@@ -556,7 +556,7 @@ packages:
     description:
       name: provider
       sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
   pub_semver:
@@ -564,7 +564,7 @@ packages:
     description:
       name: pub_semver
       sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.5"
   pubspec_parse:
@@ -572,7 +572,7 @@ packages:
     description:
       name: pubspec_parse
       sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   rational:
@@ -580,7 +580,7 @@ packages:
     description:
       name: rational
       sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   shared_preferences:
@@ -588,7 +588,7 @@ packages:
     description:
       name: shared_preferences
       sha256: "846849e3e9b68f3ef4b60c60cf4b3e02e9321bc7f4d8c4692cf87ffa82fc8a3a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.2"
   shared_preferences_android:
@@ -596,7 +596,7 @@ packages:
     description:
       name: shared_preferences_android
       sha256: ea86be7b7114f9e94fddfbb52649e59a03d6627ccd2387ebddcd6624719e9f16
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.5"
   shared_preferences_foundation:
@@ -604,7 +604,7 @@ packages:
     description:
       name: shared_preferences_foundation
       sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.4"
   shared_preferences_linux:
@@ -612,7 +612,7 @@ packages:
     description:
       name: shared_preferences_linux
       sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
@@ -620,7 +620,7 @@ packages:
     description:
       name: shared_preferences_platform_interface
       sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   shared_preferences_web:
@@ -628,7 +628,7 @@ packages:
     description:
       name: shared_preferences_web
       sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
   shared_preferences_windows:
@@ -636,7 +636,7 @@ packages:
     description:
       name: shared_preferences_windows
       sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   shelf:
@@ -644,7 +644,7 @@ packages:
     description:
       name: shelf
       sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
   shelf_web_socket:
@@ -652,7 +652,7 @@ packages:
     description:
       name: shelf_web_socket
       sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   sky_engine:
@@ -679,7 +679,7 @@ packages:
     description:
       name: source_gen
       sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   source_span:
@@ -687,7 +687,7 @@ packages:
     description:
       name: source_span
       sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
   stack_trace:
@@ -695,7 +695,7 @@ packages:
     description:
       name: stack_trace
       sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
   stream_channel:
@@ -703,7 +703,7 @@ packages:
     description:
       name: stream_channel
       sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   stream_transform:
@@ -711,7 +711,7 @@ packages:
     description:
       name: stream_transform
       sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   string_scanner:
@@ -719,7 +719,7 @@ packages:
     description:
       name: string_scanner
       sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   term_glyph:
@@ -727,7 +727,7 @@ packages:
     description:
       name: term_glyph
       sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
@@ -735,7 +735,7 @@ packages:
     description:
       name: test_api
       sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.3"
   timing:
@@ -743,7 +743,7 @@ packages:
     description:
       name: timing
       sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   typed_data:
@@ -751,7 +751,7 @@ packages:
     description:
       name: typed_data
       sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   vector_math:
@@ -759,7 +759,7 @@ packages:
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   vm_service:
@@ -767,7 +767,7 @@ packages:
     description:
       name: vm_service
       sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "14.3.0"
   watcher:
@@ -775,7 +775,7 @@ packages:
     description:
       name: watcher
       sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   web:
@@ -783,7 +783,7 @@ packages:
     description:
       name: web
       sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   web_socket:
@@ -791,7 +791,7 @@ packages:
     description:
       name: web_socket
       sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.6"
   web_socket_channel:
@@ -799,7 +799,7 @@ packages:
     description:
       name: web_socket_channel
       sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   xdg_directories:
@@ -807,7 +807,7 @@ packages:
     description:
       name: xdg_directories
       sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   yaml:
@@ -815,7 +815,7 @@ packages:
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
 sdks:

--- a/packages/solana_mobile_wallet/example/pubspec.yaml
+++ b/packages/solana_mobile_wallet/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the solana_mobile_wallet plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/packages/solana_mobile_wallet/example/pubspec.yaml
+++ b/packages/solana_mobile_wallet/example/pubspec.yaml
@@ -3,7 +3,8 @@ description: Demonstrates how to use the solana_mobile_wallet plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/packages/solana_mobile_wallet/example/pubspec.yaml
+++ b/packages/solana_mobile_wallet/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the solana_mobile_wallet plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
   flutter: ">=3.10.0"
 
 dependencies:

--- a/packages/solana_mobile_wallet/example/pubspec.yaml
+++ b/packages/solana_mobile_wallet/example/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^2.1.0+1
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
 
 flutter:
   uses-material-design: true

--- a/packages/solana_mobile_wallet/pubspec.yaml
+++ b/packages/solana_mobile_wallet/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/espresso-cash/espresso-cash-public/tree/master/pa
 issue_tracker: https://github.com/espresso-cash/espresso-cash-public/issues
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=2.5.0"
 
 dependencies:

--- a/packages/solana_mobile_wallet/pubspec.yaml
+++ b/packages/solana_mobile_wallet/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/espresso-cash/espresso-cash-public/tree/master/pa
 issue_tracker: https://github.com/espresso-cash/espresso-cash-public/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
   flutter: ">=3.10.0"
 
 dependencies:

--- a/packages/solana_mobile_wallet/pubspec.yaml
+++ b/packages/solana_mobile_wallet/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
     sdk: flutter
   freezed: ^2.1.0+1
   json_serializable: ^6.3.1
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
   pigeon: ^7.1.1
 
 flutter:

--- a/packages/solana_mobile_wallet/pubspec.yaml
+++ b/packages/solana_mobile_wallet/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/espresso-cash/espresso-cash-public/tree/master/pa
 issue_tracker: https://github.com/espresso-cash/espresso-cash-public/issues
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:

--- a/packages/solana_seed_vault/example/pubspec.lock
+++ b/packages/solana_seed_vault/example/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: d976d24314f193899a3079b14fe336215a63a3b1e1c3743eabba8f83e049e9a9
+      sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
       url: "https://pub.dev"
     source: hosted
-    version: "49.0.0"
+    version: "80.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "40ba2c6d2ab41a66476f8f1f099da6be0795c1b47221f5e2c5f8ad6048cdffae"
+      sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "7.3.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: bloc
-      sha256: bd4f8027bfa60d96c8046dec5ce74c463b2c918dce1b0d36593575995344534a
+      sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.1.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -58,61 +58,60 @@ packages:
     source: hosted
     version: "2.1.1"
   borsh_annotation:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: borsh_annotation
-      sha256: "4a226cf8b7a165ecf8020c0c8d366b2728167fd102ef9b9e89d94d86f89ac57b"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../borsh_annotation"
+      relative: true
+    source: path
     version: "0.3.1+5"
   build:
     dependency: transitive
     description:
       name: build
-      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "687cf90a3951affac1bd5f9ecb5e3e90b60487f3d9cdc359bb310f8876bb02a6"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.10"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.7"
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -125,10 +124,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "169565c8ad06adb760c3645bf71f00bff161b00002cace266cad42c5d22a7725"
+      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.3"
+    version: "8.9.3"
   characters:
     dependency: transitive
     description:
@@ -141,10 +140,10 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   clock:
     dependency: transitive
     description:
@@ -157,74 +156,74 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "0d43dd1288fd145de1ecc9a3948ad4a6d5a82f0a14c4fdd0892260787d975cbe"
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.10.1"
   collection:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.6"
   cryptography:
     dependency: transitive
     description:
       name: cryptography
-      sha256: df156c5109286340817d21fa7b62f9140f17915077127dd70f8bd7a2a0997a35
+      sha256: d146b76d33d94548cf035233fbc2f4338c1242fa119013bead807d033fc4ae05
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7a03456c3490394c8e7665890333e91ae8a49be43542b616e414449ac358acd4"
+      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.4"
+    version: "3.0.1"
   decimal:
     dependency: transitive
     description:
       name: decimal
-      sha256: eece91944f523657c75a3a008a90ec7f7eb3986191153a78570c7d0ac8ef3d01
+      sha256: "28239b8b929c1bd8618702e6dbc96e2618cf99770bbe9cb040d6cf56a11e4ec3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "3.2.1"
   dfunc:
     dependency: "direct main"
     description:
       name: dfunc
-      sha256: "634dcde12bdf6e7a104f4e46d0b00a391fa98af479f519c05f4e49d6da650335"
+      sha256: cb0e20067771ae3da6b09827d0097faec18e91c3b3100b2d966ba95b9338a296
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.1"
+    version: "0.8.2"
   ed25519_hd_key:
     dependency: transitive
     description:
       name: ed25519_hd_key
-      sha256: "326608234e986ea826a5db4cf4cd6826058d860875a3fff7926c0725fe1a604d"
+      sha256: "31e191ec97492873067e46dc9cc0c7d55170559c83a478400feffa0627acaccf"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   fake_async:
     dependency: transitive
     description:
@@ -233,22 +232,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -258,10 +265,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: "890c51c8007f0182360e523518a0c732efb89876cb4669307af7efada5b55557"
+      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.1"
+    version: "8.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -271,42 +278,42 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "4179d41127bc7a67dc3f58ceec1d22f1cdf10470653cb86eda2a63f81b4920c7"
+      sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.5.8"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
+      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.4"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.2"
   hex:
     dependency: transitive
     description:
@@ -319,34 +326,42 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   js:
     dependency: transitive
     description:
@@ -359,26 +374,26 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -391,10 +406,10 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -423,18 +438,18 @@ packages:
     dependency: "direct dev"
     description:
       name: mews_pedantic
-      sha256: e05e23939d52f7de00bcef2265f5edc3dfbee1f2bd513ba1f03500c9ab116f16
+      sha256: a2d2c5c89e03eb40ed70918f47c1fa7216059384837f9d9d1cd56f5df305cc53
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.0"
+    version: "0.27.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   nested:
     dependency: transitive
     description:
@@ -447,10 +462,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   path:
     dependency: transitive
     description:
@@ -463,26 +478,26 @@ packages:
     dependency: transitive
     description:
       name: pinenacl
-      sha256: e5fb0bce1717b7f136f35ee98b5c02b3e6383211f8a77ca882fa7812232a07b9
+      sha256: "57e907beaacbc3c024a098910b6240758e899674de07d6949a67b52fd984cbdf"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.4"
+    version: "0.6.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: dbf0f707c78beedc9200146ad3cb0ab4d5da13c246336987be6940f026500d3a
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.8"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.2"
+    version: "3.9.1"
   pool:
     dependency: transitive
     description:
@@ -495,63 +510,62 @@ packages:
     dependency: "direct main"
     description:
       name: provider
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.2"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "75f6614d6dde2dc68948dffbaa4fe5dae32cd700eb9fb763fe11dfb45a3c4d0a"
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.5.0"
   rational:
     dependency: transitive
     description:
       name: rational
-      sha256: ba58e9e18df9abde280e8b10051e4bce85091e41e8e7e411b6cde2e738d357cf
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   solana:
     dependency: "direct main"
     description:
-      name: solana
-      sha256: "3f8c9ad84af6fbce1e5d76ab67b17c9ec944185235a6032b578ecab0b1f59ee3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.31.0+1"
+      path: "../../solana"
+      relative: true
+    source: path
+    version: "0.31.2"
   solana_seed_vault:
     dependency: "direct main"
     description:
@@ -563,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "2d79738b6bbf38a43920e2b8d189e9a3ce6cc201f4b8fc76be5e4fe377b1c38d"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.6"
+    version: "2.0.0"
   source_span:
     dependency: transitive
     description:
@@ -579,10 +593,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -595,18 +609,18 @@ packages:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -619,26 +633,26 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   timing:
     dependency: transitive
     description:
       name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -651,34 +665,50 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.2"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/solana_seed_vault/example/pubspec.yaml
+++ b/packages/solana_seed_vault/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.6 <3.0.0"
+  sdk: ">=2.18.6 <4.0.0"
 
 dependencies:
   bloc: ^8.1.0

--- a/packages/solana_seed_vault/example/pubspec.yaml
+++ b/packages/solana_seed_vault/example/pubspec.yaml
@@ -5,7 +5,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.6 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   bloc: ^8.1.0

--- a/packages/solana_seed_vault/example/pubspec.yaml
+++ b/packages/solana_seed_vault/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
   flutter: ">=3.10.0"
 
 dependencies:

--- a/packages/solana_seed_vault/example/pubspec.yaml
+++ b/packages/solana_seed_vault/example/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^2.2.0
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
 
 flutter:
   uses-material-design: true

--- a/packages/solana_seed_vault/pubspec.yaml
+++ b/packages/solana_seed_vault/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/espresso-cash/espresso-cash-public/tree/master/pa
 issue_tracker: https://github.com/espresso-cash/espresso-cash-public/issues
 
 environment:
-  sdk: ">=2.18.5 <3.0.0"
+  sdk: ">=2.18.5 <4.0.0"
   flutter: ">=2.5.0"
 
 dependencies:

--- a/packages/solana_seed_vault/pubspec.yaml
+++ b/packages/solana_seed_vault/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/espresso-cash/espresso-cash-public/tree/master/pa
 issue_tracker: https://github.com/espresso-cash/espresso-cash-public/issues
 
 environment:
-  sdk: ">=2.18.5 <4.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:

--- a/packages/solana_seed_vault/pubspec.yaml
+++ b/packages/solana_seed_vault/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
     sdk: flutter
   freezed: ^2.1.0+1
   json_serializable: ^6.3.1
-  mews_pedantic: ^0.26.0
+  mews_pedantic: ^0.27.0
   mockito: ^5.3.2
   pigeon: ^7.1.1
 

--- a/packages/solana_seed_vault/pubspec.yaml
+++ b/packages/solana_seed_vault/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/espresso-cash/espresso-cash-public/tree/master/pa
 issue_tracker: https://github.com/espresso-cash/espresso-cash-public/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
   flutter: ">=3.10.0"
 
 dependencies:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,26 +13,34 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   cli_launcher:
     dependency: transitive
     description:
@@ -45,106 +53,114 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: "66f86e916d285c1a93d3b79587d94bd71984a66aac4ff74e524cfa7877f1395c"
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5"
+    version: "0.4.2"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.19.1"
   conventional_commit:
     dependency: transitive
     description:
       name: conventional_commit
-      sha256: "8eee25c315cf1946215d02d598402ca75cfee8a8ab482f3fac34cb0717323afa"
+      sha256: dec15ad1118f029c618651a4359eb9135d8b88f761aa24e4016d061cd45948f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.0+1"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.1"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.2"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "1.3.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
-  matcher:
-    dependency: transitive
-    description:
-      name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.12.14"
+    version: "4.9.0"
   melos:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: cd8e7db0250ee822c5354a8214afc751b6c1c41aadfbbef927456d509d953244
+      sha256: "3f3ab3f902843d1e5a1b1a4dd39a4aca8ba1056f2d32fd8995210fa2843f646f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "6.3.2"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.16.0"
   mustache_template:
     dependency: transitive
     description:
@@ -157,18 +173,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.1"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.6"
   pool:
     dependency: transitive
     description:
@@ -181,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "5.0.3"
   prompts:
     dependency: transitive
     description:
@@ -197,97 +213,89 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   pub_updater:
     dependency: transitive
     description:
       name: pub_updater
-      sha256: "42890302ab2672adf567dc2b20e55b4ecc29d7e19c63b6b98143ab68dd717d3a"
+      sha256: "54e8dc865349059ebe7f163d6acce7c89eb958b8047e6d6e80ce93b13d7c9e60"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
-  pubspec:
+    version: "0.4.0"
+  pubspec_parse:
     dependency: transitive
     description:
-      name: pubspec
-      sha256: f534a50a2b4d48dc3bc0ec147c8bd7c304280fff23b153f3f11803c4d49d927e
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      sha256: b1c1ac5ce6688d77f65f3375a9abb9319b3cb32486bdc7a1e0fdf004d7ba4e47
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.1"
+    version: "1.5.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
-  uri:
+    version: "1.4.0"
+  web:
     dependency: transitive
     description:
-      name: uri
-      sha256: "889eea21e953187c6099802b7b4cf5219ba8f3518f604a1033064d45b1b8268a"
+      name: web
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   yaml_edit:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: "0b968021754d8fbd3e9c83563b538ee417d88b2cc587606da5615546b7ee033b"
+      sha256: fb38626579fb345ad00e674e2af3a5c9b0cc4b9bfb8fd7f7ff322c7c9e62aef5
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.2"
 sdks:
-  dart: ">=2.18.0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: espresso_cash_workspace
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dev_dependencies:
-  melos: any
+  melos: ^6.3.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: espresso_cash_workspace
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
   melos: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: espresso_cash_workspace
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
-  
+  sdk: '>=2.18.0 <4.0.0'
+
 dev_dependencies:
-  melos: ^3.0.0
+  melos: any


### PR DESCRIPTION
## Changes

1. `package:mews_pedantic` was upgraded from `^0.26.0` to `^0.27.0` to match the DCM version (v1.17.0). (See [changelog](https://pub.dev/packages/mews_pedantic/changelog))
2. SDK constraints were updated from `>=2.x.0 <3.0.0` to `^3.0.0` since `package:mews_pedantic` implied. (See [versions](https://pub.dev/packages/mews_pedantic/versions))
3. `package:analyzer` was constrained to `>=5.4.0 <8.0.0` since the SDK constraint implied and no breaking changes to `*Element` classes within the usages of packages (see [versions](https://pub.dev/packages/analyzer/versions)). Some usages are deprecated and this request ignores them until we rebased to the next major version.
4. `package:source_gen` was constrained to `">=1.4.0 <3.0.0"` since the SDK constraint implied and no breaking changes within the usages of packages. (See [versions](https://pub.dev/packages/source_gen/versions))
5. `package:source_helper` was upgraded to `"^1.3.4"` since the SDK constraint implied. (See [versions](https://pub.dev/packages/source_helper/versions))
6. `package:solana` now allows `package:decimal` v3 to be resolved.
7. `package:melos` was upgraded from `3.0.0` to `6.3.2`.
8. Regenerate files since dependencies were upgraded.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
