### PR TITLE
feat: Allow parsing big number from string value

### DIFF
--- a/packages/solana/lib/src/rpc/dto/account.dart
+++ b/packages/solana/lib/src/rpc/dto/account.dart
@@ -1,44 +1,37 @@
-import 'package:json_annotation/json_annotation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:solana/src/rpc/dto/account_data/account_data.dart';
 import 'package:solana/src/rpc/dto/context.dart';
 import 'package:solana/src/rpc/helpers.dart';
 
+part 'account.freezed.dart';
+
 part 'account.g.dart';
 
 /// An account
-@JsonSerializable()
-class Account {
-  const Account({
-    required this.lamports,
-    required this.owner,
-    required this.data,
-    required this.executable,
-    required this.rentEpoch,
-  });
+@freezed
+class Account with _$Account {
+  const factory Account({
+    /// Number of lamports assigned to this account, as a u64
+    required int lamports,
+
+    /// base-58 encoded Pubkey of the program this account has been
+    /// assigned to
+    required String owner,
+
+    /// Data associated with the account, either as encoded binary
+    /// data or JSON format {program: state}, depending on
+    /// encoding parameter
+    required AccountData? data,
+
+    /// Boolean indicating if the account contains a program (and
+    /// is strictly read-only)
+    required bool executable,
+
+    /// The epoch at which this account will next owe rent, as u64
+    @JsonKey(fromJson: bigIntFromJson) required BigInt rentEpoch,
+  }) = _Account;
 
   factory Account.fromJson(Map<String, dynamic> json) => _$AccountFromJson(json);
-
-  /// Number of lamports assigned to this account, as a u64
-  final int lamports;
-
-  /// base-58 encoded Pubkey of the program this account has been
-  /// assigned to
-  final String owner;
-
-  /// Data associated with the account, either as encoded binary
-  /// data or JSON format {program: state}, depending on
-  /// encoding parameter
-  final AccountData? data;
-
-  /// Boolean indicating if the account contains a program (and
-  /// is strictly read-only)
-  final bool executable;
-
-  /// The epoch at which this account will next owe rent, as u64
-  @JsonKey(fromJson: bigIntFromNum)
-  final BigInt rentEpoch;
-
-  Map<String, dynamic> toJson() => _$AccountToJson(this);
 }
 
 @JsonSerializable()

--- a/packages/solana/lib/src/rpc/dto/account.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/account.freezed.dart
@@ -1,0 +1,298 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'account.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+Account _$AccountFromJson(Map<String, dynamic> json) {
+  return _Account.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Account {
+  /// Number of lamports assigned to this account, as a u64
+  int get lamports => throw _privateConstructorUsedError;
+
+  /// base-58 encoded Pubkey of the program this account has been
+  /// assigned to
+  String get owner => throw _privateConstructorUsedError;
+
+  /// Data associated with the account, either as encoded binary
+  /// data or JSON format {<program>: <state>}, depending on
+  /// encoding parameter
+  AccountData? get data => throw _privateConstructorUsedError;
+
+  /// Boolean indicating if the account contains a program (and
+  /// is strictly read-only)
+  bool get executable => throw _privateConstructorUsedError;
+
+  /// The epoch at which this account will next owe rent, as u64
+  @JsonKey(fromJson: bigIntFromJson)
+  BigInt get rentEpoch => throw _privateConstructorUsedError;
+
+  /// Serializes this Account to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Account
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AccountCopyWith<Account> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AccountCopyWith<$Res> {
+  factory $AccountCopyWith(Account value, $Res Function(Account) then) =
+      _$AccountCopyWithImpl<$Res, Account>;
+  @useResult
+  $Res call({
+    int lamports,
+    String owner,
+    AccountData? data,
+    bool executable,
+    @JsonKey(fromJson: bigIntFromJson) BigInt rentEpoch,
+  });
+}
+
+/// @nodoc
+class _$AccountCopyWithImpl<$Res, $Val extends Account> implements $AccountCopyWith<$Res> {
+  _$AccountCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Account
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? lamports = null,
+    Object? owner = null,
+    Object? data = freezed,
+    Object? executable = null,
+    Object? rentEpoch = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            lamports:
+                null == lamports
+                    ? _value.lamports
+                    : lamports // ignore: cast_nullable_to_non_nullable
+                        as int,
+            owner:
+                null == owner
+                    ? _value.owner
+                    : owner // ignore: cast_nullable_to_non_nullable
+                        as String,
+            data:
+                freezed == data
+                    ? _value.data
+                    : data // ignore: cast_nullable_to_non_nullable
+                        as AccountData?,
+            executable:
+                null == executable
+                    ? _value.executable
+                    : executable // ignore: cast_nullable_to_non_nullable
+                        as bool,
+            rentEpoch:
+                null == rentEpoch
+                    ? _value.rentEpoch
+                    : rentEpoch // ignore: cast_nullable_to_non_nullable
+                        as BigInt,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$AccountImplCopyWith<$Res> implements $AccountCopyWith<$Res> {
+  factory _$$AccountImplCopyWith(_$AccountImpl value, $Res Function(_$AccountImpl) then) =
+      __$$AccountImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    int lamports,
+    String owner,
+    AccountData? data,
+    bool executable,
+    @JsonKey(fromJson: bigIntFromJson) BigInt rentEpoch,
+  });
+}
+
+/// @nodoc
+class __$$AccountImplCopyWithImpl<$Res> extends _$AccountCopyWithImpl<$Res, _$AccountImpl>
+    implements _$$AccountImplCopyWith<$Res> {
+  __$$AccountImplCopyWithImpl(_$AccountImpl _value, $Res Function(_$AccountImpl) _then)
+    : super(_value, _then);
+
+  /// Create a copy of Account
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? lamports = null,
+    Object? owner = null,
+    Object? data = freezed,
+    Object? executable = null,
+    Object? rentEpoch = null,
+  }) {
+    return _then(
+      _$AccountImpl(
+        lamports:
+            null == lamports
+                ? _value.lamports
+                : lamports // ignore: cast_nullable_to_non_nullable
+                    as int,
+        owner:
+            null == owner
+                ? _value.owner
+                : owner // ignore: cast_nullable_to_non_nullable
+                    as String,
+        data:
+            freezed == data
+                ? _value.data
+                : data // ignore: cast_nullable_to_non_nullable
+                    as AccountData?,
+        executable:
+            null == executable
+                ? _value.executable
+                : executable // ignore: cast_nullable_to_non_nullable
+                    as bool,
+        rentEpoch:
+            null == rentEpoch
+                ? _value.rentEpoch
+                : rentEpoch // ignore: cast_nullable_to_non_nullable
+                    as BigInt,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$AccountImpl implements _Account {
+  const _$AccountImpl({
+    required this.lamports,
+    required this.owner,
+    required this.data,
+    required this.executable,
+    @JsonKey(fromJson: bigIntFromJson) required this.rentEpoch,
+  });
+
+  factory _$AccountImpl.fromJson(Map<String, dynamic> json) => _$$AccountImplFromJson(json);
+
+  /// Number of lamports assigned to this account, as a u64
+  @override
+  final int lamports;
+
+  /// base-58 encoded Pubkey of the program this account has been
+  /// assigned to
+  @override
+  final String owner;
+
+  /// Data associated with the account, either as encoded binary
+  /// data or JSON format {program: state}, depending on
+  /// encoding parameter
+  @override
+  final AccountData? data;
+
+  /// Boolean indicating if the account contains a program (and
+  /// is strictly read-only)
+  @override
+  final bool executable;
+
+  /// The epoch at which this account will next owe rent, as u64
+  @override
+  @JsonKey(fromJson: bigIntFromJson)
+  final BigInt rentEpoch;
+
+  @override
+  String toString() {
+    return 'Account(lamports: $lamports, owner: $owner, data: $data, executable: $executable, rentEpoch: $rentEpoch)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AccountImpl &&
+            (identical(other.lamports, lamports) || other.lamports == lamports) &&
+            (identical(other.owner, owner) || other.owner == owner) &&
+            (identical(other.data, data) || other.data == data) &&
+            (identical(other.executable, executable) || other.executable == executable) &&
+            (identical(other.rentEpoch, rentEpoch) || other.rentEpoch == rentEpoch));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, lamports, owner, data, executable, rentEpoch);
+
+  /// Create a copy of Account
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AccountImplCopyWith<_$AccountImpl> get copyWith =>
+      __$$AccountImplCopyWithImpl<_$AccountImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$AccountImplToJson(this);
+  }
+}
+
+abstract class _Account implements Account {
+  const factory _Account({
+    required final int lamports,
+    required final String owner,
+    required final AccountData? data,
+    required final bool executable,
+    @JsonKey(fromJson: bigIntFromJson) required final BigInt rentEpoch,
+  }) = _$AccountImpl;
+
+  factory _Account.fromJson(Map<String, dynamic> json) = _$AccountImpl.fromJson;
+
+  /// Number of lamports assigned to this account, as a u64
+  @override
+  int get lamports;
+
+  /// base-58 encoded Pubkey of the program this account has been
+  /// assigned to
+  @override
+  String get owner;
+
+  /// Data associated with the account, either as encoded binary
+  /// data or JSON format {<program>: <state>}, depending on
+  /// encoding parameter
+  @override
+  AccountData? get data;
+
+  /// Boolean indicating if the account contains a program (and
+  /// is strictly read-only)
+  @override
+  bool get executable;
+
+  /// The epoch at which this account will next owe rent, as u64
+  @override
+  @JsonKey(fromJson: bigIntFromJson)
+  BigInt get rentEpoch;
+
+  /// Create a copy of Account
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AccountImplCopyWith<_$AccountImpl> get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/solana/lib/src/rpc/dto/account.g.dart
+++ b/packages/solana/lib/src/rpc/dto/account.g.dart
@@ -6,22 +6,6 @@ part of 'account.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-Account _$AccountFromJson(Map<String, dynamic> json) => Account(
-  lamports: (json['lamports'] as num).toInt(),
-  owner: json['owner'] as String,
-  data: json['data'] == null ? null : AccountData.fromJson(json['data']),
-  executable: json['executable'] as bool,
-  rentEpoch: bigIntFromNum(json['rentEpoch'] as num),
-);
-
-Map<String, dynamic> _$AccountToJson(Account instance) => <String, dynamic>{
-  'lamports': instance.lamports,
-  'owner': instance.owner,
-  'data': instance.data?.toJson(),
-  'executable': instance.executable,
-  'rentEpoch': instance.rentEpoch.toString(),
-};
-
 AccountResult _$AccountResultFromJson(Map<String, dynamic> json) => AccountResult(
   context: Context.fromJson(json['context'] as Map<String, dynamic>),
   value: json['value'] == null ? null : Account.fromJson(json['value'] as Map<String, dynamic>),
@@ -46,3 +30,19 @@ Map<String, dynamic> _$MultipleAccountsResultToJson(MultipleAccountsResult insta
       'context': instance.context.toJson(),
       'value': instance.value.map((e) => e?.toJson()).toList(),
     };
+
+_$AccountImpl _$$AccountImplFromJson(Map<String, dynamic> json) => _$AccountImpl(
+  lamports: (json['lamports'] as num).toInt(),
+  owner: json['owner'] as String,
+  data: json['data'] == null ? null : AccountData.fromJson(json['data']),
+  executable: json['executable'] as bool,
+  rentEpoch: bigIntFromJson(json['rentEpoch'] as Object),
+);
+
+Map<String, dynamic> _$$AccountImplToJson(_$AccountImpl instance) => <String, dynamic>{
+  'lamports': instance.lamports,
+  'owner': instance.owner,
+  'data': instance.data?.toJson(),
+  'executable': instance.executable,
+  'rentEpoch': instance.rentEpoch.toString(),
+};

--- a/packages/solana/lib/src/rpc/dto/context.dart
+++ b/packages/solana/lib/src/rpc/dto/context.dart
@@ -1,6 +1,8 @@
-import 'package:json_annotation/json_annotation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'package:solana/src/rpc/helpers.dart';
+
+part 'context.freezed.dart';
 
 part 'context.g.dart';
 
@@ -11,14 +13,9 @@ class ContextResult<T> {
   final T value;
 }
 
-@JsonSerializable()
-class Context {
-  Context({required this.slot});
+@freezed
+class Context with _$Context {
+  const factory Context({@JsonKey(fromJson: bigIntFromJson) required BigInt slot}) = _Context;
 
   factory Context.fromJson(Map<String, dynamic> json) => _$ContextFromJson(json);
-
-  @JsonKey(fromJson: bigIntFromNum)
-  BigInt slot;
-
-  Map<String, dynamic> toJson() => _$ContextToJson(this);
 }

--- a/packages/solana/lib/src/rpc/dto/context.freezed.dart
+++ b/packages/solana/lib/src/rpc/dto/context.freezed.dart
@@ -1,0 +1,160 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'context.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+Context _$ContextFromJson(Map<String, dynamic> json) {
+  return _Context.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Context {
+  @JsonKey(fromJson: bigIntFromJson)
+  BigInt get slot => throw _privateConstructorUsedError;
+
+  /// Serializes this Context to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Context
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ContextCopyWith<Context> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ContextCopyWith<$Res> {
+  factory $ContextCopyWith(Context value, $Res Function(Context) then) =
+      _$ContextCopyWithImpl<$Res, Context>;
+  @useResult
+  $Res call({@JsonKey(fromJson: bigIntFromJson) BigInt slot});
+}
+
+/// @nodoc
+class _$ContextCopyWithImpl<$Res, $Val extends Context> implements $ContextCopyWith<$Res> {
+  _$ContextCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Context
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? slot = null}) {
+    return _then(
+      _value.copyWith(
+            slot:
+                null == slot
+                    ? _value.slot
+                    : slot // ignore: cast_nullable_to_non_nullable
+                        as BigInt,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ContextImplCopyWith<$Res> implements $ContextCopyWith<$Res> {
+  factory _$$ContextImplCopyWith(_$ContextImpl value, $Res Function(_$ContextImpl) then) =
+      __$$ContextImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({@JsonKey(fromJson: bigIntFromJson) BigInt slot});
+}
+
+/// @nodoc
+class __$$ContextImplCopyWithImpl<$Res> extends _$ContextCopyWithImpl<$Res, _$ContextImpl>
+    implements _$$ContextImplCopyWith<$Res> {
+  __$$ContextImplCopyWithImpl(_$ContextImpl _value, $Res Function(_$ContextImpl) _then)
+    : super(_value, _then);
+
+  /// Create a copy of Context
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? slot = null}) {
+    return _then(
+      _$ContextImpl(
+        slot:
+            null == slot
+                ? _value.slot
+                : slot // ignore: cast_nullable_to_non_nullable
+                    as BigInt,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ContextImpl implements _Context {
+  const _$ContextImpl({@JsonKey(fromJson: bigIntFromJson) required this.slot});
+
+  factory _$ContextImpl.fromJson(Map<String, dynamic> json) => _$$ContextImplFromJson(json);
+
+  @override
+  @JsonKey(fromJson: bigIntFromJson)
+  final BigInt slot;
+
+  @override
+  String toString() {
+    return 'Context(slot: $slot)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ContextImpl &&
+            (identical(other.slot, slot) || other.slot == slot));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, slot);
+
+  /// Create a copy of Context
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ContextImplCopyWith<_$ContextImpl> get copyWith =>
+      __$$ContextImplCopyWithImpl<_$ContextImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ContextImplToJson(this);
+  }
+}
+
+abstract class _Context implements Context {
+  const factory _Context({@JsonKey(fromJson: bigIntFromJson) required final BigInt slot}) =
+      _$ContextImpl;
+
+  factory _Context.fromJson(Map<String, dynamic> json) = _$ContextImpl.fromJson;
+
+  @override
+  @JsonKey(fromJson: bigIntFromJson)
+  BigInt get slot;
+
+  /// Create a copy of Context
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ContextImplCopyWith<_$ContextImpl> get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/solana/lib/src/rpc/dto/context.g.dart
+++ b/packages/solana/lib/src/rpc/dto/context.g.dart
@@ -6,9 +6,9 @@ part of 'context.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-Context _$ContextFromJson(Map<String, dynamic> json) =>
-    Context(slot: bigIntFromNum(json['slot'] as num));
+_$ContextImpl _$$ContextImplFromJson(Map<String, dynamic> json) =>
+    _$ContextImpl(slot: bigIntFromJson(json['slot'] as Object));
 
-Map<String, dynamic> _$ContextToJson(Context instance) => <String, dynamic>{
+Map<String, dynamic> _$$ContextImplToJson(_$ContextImpl instance) => <String, dynamic>{
   'slot': instance.slot.toString(),
 };

--- a/packages/solana/lib/src/rpc/helpers.dart
+++ b/packages/solana/lib/src/rpc/helpers.dart
@@ -45,4 +45,8 @@ dynamic unwrapAndGetResult(dynamic raw) {
 }
 
 @internal
-BigInt bigIntFromNum(num value) => BigInt.from(value);
+BigInt bigIntFromJson(Object value) => switch (value) {
+  num() => BigInt.from(value),
+  String() => BigInt.parse(value),
+  _ => BigInt.parse('$value'),
+};

--- a/packages/solana/test/rpc_client_test.dart
+++ b/packages/solana/test/rpc_client_test.dart
@@ -13,6 +13,79 @@ import 'config.dart';
 const int _transferredAmount = lamportsPerSol;
 
 void main() {
+  group('Instance equality', () {
+    test('Account', () {
+      final accounts = <(Account, Account)>[
+        (
+          Account.fromJson({
+            'lamports': 0,
+            'owner': SystemProgram.programId,
+            'executable': false,
+            'rentEpoch': 0,
+          }),
+          Account.fromJson({
+            'lamports': 0,
+            'owner': SystemProgram.programId,
+            'executable': false,
+            'rentEpoch': '0',
+          }),
+        ),
+        // Web max precise.
+        (
+          Account.fromJson({
+            'lamports': 0,
+            'owner': SystemProgram.programId,
+            'executable': false,
+            'rentEpoch': 0x20000000000000,
+          }),
+          Account.fromJson({
+            'lamports': 0,
+            'owner': SystemProgram.programId,
+            'executable': false,
+            'rentEpoch': '0x20000000000000',
+          }),
+        ),
+        // 64-bit native.
+        (
+          Account.fromJson({
+            'lamports': 0,
+            'owner': SystemProgram.programId,
+            'executable': false,
+            'rentEpoch': 0x7FFFFFFFFFFFFFFF,
+          }),
+          Account.fromJson({
+            'lamports': 0,
+            'owner': SystemProgram.programId,
+            'executable': false,
+            'rentEpoch': '0x7FFFFFFFFFFFFFFF',
+          }),
+        ),
+      ];
+      for (final pair in accounts) {
+        expect(pair.$1 == pair.$2, true);
+      }
+    });
+
+    test('Context', () {
+      final contexts = <(Context, Context)>[
+        (Context.fromJson({'slot': 0}), Context.fromJson({'slot': '0'})),
+        // Web max precise.
+        (
+          Context.fromJson({'slot': 0x20000000000000}),
+          Context.fromJson({'slot': '0x20000000000000'}),
+        ),
+        // 64-bit native.
+        (
+          Context.fromJson({'slot': 0x7FFFFFFFFFFFFFFF}),
+          Context.fromJson({'slot': '0x7FFFFFFFFFFFFFFF'}),
+        ),
+      ];
+      for (final pair in contexts) {
+        expect(pair.$1 == pair.$2, true);
+      }
+    });
+  });
+
   group('Timeout exceptions', () {
     test('throws exception with method name on timeout', () {
       final client = RpcClient(devnetRpcUrl, timeout: Duration.zero);


### PR DESCRIPTION
## Changes

`BigInt`s were deserialized from `num` in the code base but serialized to `String`s. The type becomes incompatible when a cache layer stores the serialized data and deserializes them when reading from the cache.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [x] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
