### PR TITLE
feat: Gracefully fetch external json

### DIFF
--- a/packages/solana/lib/src/metaplex/accounts/metadata.dart
+++ b/packages/solana/lib/src/metaplex/accounts/metadata.dart
@@ -34,8 +34,17 @@ class Metadata {
     );
   }
 
-  Future<OffChainMetadata> getExternalJson() async {
-    final response = await http.get(Uri.parse(uri));
+  Future<OffChainMetadata?> getExternalJson() async {
+    final url = this.uri.trim();
+    if (url.isEmpty) {
+      return null;
+    }
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      return null;
+    }
+
+    final response = await http.get(uri);
     if (response.statusCode != 200) {
       throw HttpException(response.statusCode, response.body);
     }


### PR DESCRIPTION
## Changes

The `uri` field could be empty for some of the tokens, for example, USDC (*6GpMXZmS7bBHBc9TrVRFUaerSQXYJPkpq31aET3UWd4R*).

```json
{
  "name": "USD Coin",
  "symbol": "USDC",
  "uri": "",
  "updateAuthority": "2wmVCSfPxGPjrnMMn7rchp4uaeoTqN39mXFC2zhPdri9",
  "mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
}
```

The change will make sure to request a valid URI or return the null result rather than throws.

## Checklist

- [ ] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
