### PR TITLE
feat: add `Ed25519HDPublicKey.isValidFromBase58`

### DIFF
--- a/packages/solana/test/hd_keypair_test.dart
+++ b/packages/solana/test/hd_keypair_test.dart
@@ -58,6 +58,15 @@ void main() {
     });
   });
 
+  test('Can determine valid public key from base58', () {
+    for (final key in _withSeedKeyDerivationData.keys) {
+      expect(Ed25519HDPublicKey.isValidFromBase58(key), true);
+    }
+    expect(Ed25519HDPublicKey.isValidFromBase58('11111111111111111111111111111111'), true);
+    expect(Ed25519HDPublicKey.isValidFromBase58('111111111111111111111111111111111'), false);
+    expect(Ed25519HDPublicKey.isValidFromBase58('malformed'), false);
+  });
+
   test('Can copy a key pair data if bytes are not destroyed', () async {
     final randomKeyPair = await Ed25519HDKeyPair.random();
     final simpleKeyPairData = await randomKeyPair.extract();


### PR DESCRIPTION
## Changes

Now users can easily determine whether a string data matches the pattern of the public key.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [x] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
