### PR TITLE
fix: send token separator input

### DIFF
--- a/packages/espressocash_app/lib/features/token_send/widgets/token_input.dart
+++ b/packages/espressocash_app/lib/features/token_send/widgets/token_input.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import '../../../l10n/device_locale.dart';
 import '../../../ui/button.dart';
 import '../../../ui/colors.dart';
-import '../../../ui/number_formatter.dart';
 import '../../../ui/text_field.dart';
 import '../../conversion_rates/widgets/extensions.dart';
 import '../../currency/models/amount.dart';
@@ -91,8 +90,7 @@ class _TokenQuantityInputState extends State<TokenQuantityInput> {
     ],
   );
 
-  Decimal get _parsedAmount =>
-      widget._quantityController.text.toDecimalOrZero(DeviceLocale.localeOf(context));
+  Decimal get _parsedAmount => widget._quantityController.text.toDecimalOrZero();
 
   bool get _isMax => _parsedAmount == widget.crypto.decimal;
 
@@ -110,4 +108,16 @@ class _TokenQuantityInputState extends State<TokenQuantityInput> {
                 DeviceLocale.localeOf(context),
                 skipSymbol: true,
               );
+}
+
+extension on String {
+  Decimal toDecimalOrZero() {
+    try {
+      final normalizedInput = replaceAll(',', '.');
+
+      return Decimal.tryParse(normalizedInput) ?? Decimal.zero;
+    } on FormatException catch (_) {
+      return Decimal.zero;
+    }
+  }
 }

--- a/packages/espressocash_app/lib/ui/number_formatter.dart
+++ b/packages/espressocash_app/lib/ui/number_formatter.dart
@@ -5,8 +5,9 @@ import 'package:intl/intl.dart';
 extension NumberFormatterExt on String {
   Decimal toDecimalOrZero(Locale locale) {
     try {
+      final normalizedInput = replaceAll(',', '.');
       final formatter = NumberFormat.decimalPattern(locale.languageCode)..minimumFractionDigits = 2;
-      final formatted = formatter.parse(this);
+      final formatted = formatter.parse(normalizedInput);
 
       return Decimal.tryParse(formatted.toString()) ?? Decimal.zero;
     } on FormatException catch (_) {

--- a/packages/espressocash_app/lib/ui/number_formatter.dart
+++ b/packages/espressocash_app/lib/ui/number_formatter.dart
@@ -5,9 +5,8 @@ import 'package:intl/intl.dart';
 extension NumberFormatterExt on String {
   Decimal toDecimalOrZero(Locale locale) {
     try {
-      final normalizedInput = replaceAll(',', '.');
       final formatter = NumberFormat.decimalPattern(locale.languageCode)..minimumFractionDigits = 2;
-      final formatted = formatter.parse(normalizedInput);
+      final formatted = formatter.parse(this);
 
       return Decimal.tryParse(formatted.toString()) ?? Decimal.zero;
     } on FormatException catch (_) {


### PR DESCRIPTION
## Changes

Fixes send token amount calculation with **,** separator

## Related issues

Fixes https://github.com/espresso-cash/espresso-cash-meta/issues/17

## Screenshot

<details><summary>Preview</summary>

![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-18 at 21 33 51](https://github.com/user-attachments/assets/f6f12580-a8b2-45a2-b565-e393c8c236c3)

</details>

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
