### PR TITLE
fix: remove round token amount

### DIFF
--- a/packages/espressocash_app/lib/features/token_details/screens/token_details_screen.dart
+++ b/packages/espressocash_app/lib/features/token_details/screens/token_details_screen.dart
@@ -159,7 +159,7 @@ class _TokenHeader extends StatelessWidget {
               const SizedBox(height: 24),
               FittedBox(
                 child: Text(
-                  context.formatWithMinAmount(crypto),
+                  crypto.format(context.locale),
                   maxLines: 1,
                   style: const TextStyle(fontSize: 59, fontWeight: FontWeight.w700),
                 ),


### PR DESCRIPTION
## Changes

Removes rounding token amount in token details page.

## Related issues

Fixes https://github.com/espresso-cash/espresso-cash-meta/issues/15

## Screenshot

<details><summary>Preview</summary>

![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-18 at 21 32 57](https://github.com/user-attachments/assets/f6610ac2-dd8e-4ac8-946a-9b9c2d8cb898)

</details>

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
