### PR TITLE
fix(solana): make SubscriptionClient work on web

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -12,6 +12,8 @@ env:
   FLUTTER_VERSION: "3.38.3"
   DART_VERSION: "3.10.1"
   DCM_VERSION: "1.35.0"
+  DCM_CI_KEY: ${{ secrets.DCM_CI_KEY }}
+  DCM_EMAIL: ${{ vars.DCM_EMAIL }}
 
 jobs:
   formatting:

--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -11,7 +11,7 @@ concurrency:
 env:
   FLUTTER_VERSION: "3.38.3"
   DART_VERSION: "3.10.1"
-  DCM_VERSION: "1.28.2"
+  DCM_VERSION: "1.35.0"
 
 jobs:
   formatting:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
 
 ## Project Overview
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dart_get:
 
 dart_analyze:
 	dart analyze --fatal-infos .
-	dcm analyze --fatal-style --fatal-performance --fatal-warnings lib
+	dcm analyze --fatal-style --fatal-warnings lib
 
 dart_test:
 	dart test
@@ -46,7 +46,7 @@ flutter_generate_test_schemas:
 
 flutter_analyze:
 	flutter analyze --fatal-infos
-	dcm analyze --fatal-style --fatal-performance --fatal-warnings lib
+	dcm analyze --fatal-style --fatal-warnings lib
 
 flutter_check_unused_code:
 	dcm check-unused-code lib --fatal-unused --exclude=$(excludeUnused)

--- a/packages/espressocash_app/analysis_options.yaml
+++ b/packages/espressocash_app/analysis_options.yaml
@@ -23,7 +23,7 @@ analyzer:
     deprecated_member_use: ignore
     deprecated_member_use_from_same_package: ignore
     require_trailing_commas: ignore
-    
+
 dart_code_metrics:
   rules:
     avoid-nested-assignments: false
@@ -58,8 +58,10 @@ dart_code_metrics:
     avoid-returning-cascades: false
     prefer-abstract-final-static-class: false
     prefer-boolean-prefixes: false
+    prefer-conditional-expressions: false
     prefer-correct-handler-name: false
     prefer-named-parameters: false
+    prefer-returning-conditional-expressions: false
     prefer-static-method: false
 
   rules-exclude:

--- a/packages/espressocash_app/lib/features/ambassador/data/ambassador_service.dart
+++ b/packages/espressocash_app/lib/features/ambassador/data/ambassador_service.dart
@@ -12,7 +12,6 @@ typedef AmbassadorStatus = ({bool isAmbassador, bool isReferral});
 class AmbassadorService extends ValueNotifier<AmbassadorStatus> {
   AmbassadorService(this._ecClient, this._storage) : super(_defaultAmbassadorStatus);
 
-  // ignore: dispose-class-fields, false positive
   final EspressoCashClient _ecClient;
   final SharedPreferences _storage;
 

--- a/packages/espressocash_app/lib/features/balances/data/repository.dart
+++ b/packages/espressocash_app/lib/features/balances/data/repository.dart
@@ -15,7 +15,6 @@ import '../../tokens/token.dart';
 class TokenBalancesRepository {
   const TokenBalancesRepository(this._db, this._tokenRepository);
 
-  // ignore: dispose-class-fields, false positive
   final MyDatabase _db;
   final TokenRepository _tokenRepository;
 

--- a/packages/espressocash_app/lib/features/conversion_rates/data/repository.dart
+++ b/packages/espressocash_app/lib/features/conversion_rates/data/repository.dart
@@ -26,10 +26,8 @@ class ConversionRatesRepository {
        _ecClient = ecClient,
        _jupiterClient = jupiterClient;
 
-  // ignore: dispose-class-fields, false positive
   final MyDatabase _db;
   final JupiterPriceClient _jupiterClient;
-  // ignore: dispose-class-fields, false positive
   final EspressoCashClient _ecClient;
   final AsyncCache<void> _cache = AsyncCache(const Duration(minutes: 1));
 

--- a/packages/espressocash_app/lib/features/onboarding/data/onboarding_repository.dart
+++ b/packages/espressocash_app/lib/features/onboarding/data/onboarding_repository.dart
@@ -13,7 +13,6 @@ class OnboardingRepository extends ChangeNotifier {
   }
 
   final SharedPreferences _storage;
-  // ignore: dispose-class-fields, false positive
   final ProfileRepository _profileRepository;
   final MyAccount _account;
 

--- a/packages/espressocash_app/lib/features/outgoing_dln_payments/services/confirm_payment_bloc.dart
+++ b/packages/espressocash_app/lib/features/outgoing_dln_payments/services/confirm_payment_bloc.dart
@@ -39,7 +39,6 @@ class ConfirmPaymentBloc extends Bloc<_Event, _State> {
   }
 
   final QuoteRepository _quoteRepository;
-  // ignore: dispose-class-fields, false positive
   final TokenBalancesRepository _balancesRepository;
 
   Timer? _timer;

--- a/packages/espressocash_app/lib/features/ramp/partners/coinflow/services/coinflow_off_ramp_order_watcher.dart
+++ b/packages/espressocash_app/lib/features/ramp/partners/coinflow/services/coinflow_off_ramp_order_watcher.dart
@@ -20,7 +20,6 @@ import '../data/coinflow_api_client.dart';
 class CoinflowOffRampOrderWatcher implements RampWatcher {
   CoinflowOffRampOrderWatcher(this._db, this._client, this._account, this._analytics);
 
-  // ignore: dispose-class-fields, false positive
   final MyDatabase _db;
   final CoinflowClient _client;
   final ECWallet _account;

--- a/packages/espressocash_app/lib/features/ramp/partners/kado/services/kado_off_ramp_order_watcher.dart
+++ b/packages/espressocash_app/lib/features/ramp/partners/kado/services/kado_off_ramp_order_watcher.dart
@@ -16,7 +16,6 @@ import '../data/kado_api_client.dart';
 class KadoOffRampOrderWatcher implements RampWatcher {
   KadoOffRampOrderWatcher(this._db, this._client, this._analytics);
 
-  // ignore: dispose-class-fields, false positive
   final MyDatabase _db;
   final KadoApiClient _client;
   final AnalyticsManager _analytics;

--- a/packages/espressocash_app/lib/features/ramp/partners/kado/services/kado_on_ramp_order_watcher.dart
+++ b/packages/espressocash_app/lib/features/ramp/partners/kado/services/kado_on_ramp_order_watcher.dart
@@ -18,7 +18,6 @@ import '../data/kado_api_client.dart';
 class KadoOnRampOrderWatcher implements RampWatcher {
   KadoOnRampOrderWatcher(this._db, this._client, this._analytics);
 
-  // ignore: dispose-class-fields, false positive
   final MyDatabase _db;
   final KadoApiClient _client;
   final AnalyticsManager _analytics;

--- a/packages/espressocash_app/lib/features/ramp/widgets/ramp_textfield.dart
+++ b/packages/espressocash_app/lib/features/ramp/widgets/ramp_textfield.dart
@@ -34,7 +34,7 @@ class RampTextField extends StatelessWidget {
                 height: 36.h,
               )
             : _defaultLogo,
-      CryptoCurrency(:final Token token) => TokenIcon(token: token, size: 40.w),
+      CryptoCurrency(:final token) => TokenIcon(token: token, size: 40.w),
       _ => _defaultLogo,
     };
 

--- a/packages/espressocash_app/lib/features/ramp/widgets/ramp_textfield.dart
+++ b/packages/espressocash_app/lib/features/ramp/widgets/ramp_textfield.dart
@@ -6,7 +6,6 @@ import '../../../gen/assets.gen.dart';
 import '../../../ui/colors.dart';
 import '../../../ui/text_field.dart';
 import '../../currency/models/currency.dart';
-import '../../tokens/token.dart';
 import '../../tokens/widgets/token_icon.dart';
 import 'ramp_loader.dart';
 

--- a/packages/espressocash_app/lib/ui/timeline.dart
+++ b/packages/espressocash_app/lib/ui/timeline.dart
@@ -74,10 +74,10 @@ class _State extends State<CpTimeline> with SingleTickerProviderStateMixin {
         _AnimationTransformer? connectorTransformer;
 
         final isActive = index == widget.active;
-        final isHighlighted = widget.animated && index == widget.active;
+        final isHighlighted = widget.animated && isActive;
 
         if (widget.animated) {
-          if (index == widget.active) {
+          if (isActive) {
             indicatorTransformer = _lowerIndicatorTransformer;
           } else if (index == widget.active - 1) {
             connectorTransformer = _connectorTransformer;

--- a/packages/solana/analysis_options.yaml
+++ b/packages/solana/analysis_options.yaml
@@ -12,9 +12,15 @@ analyzer:
 
 dart_code_metrics:
   rules:
+    avoid-type-casts:
+      exclude:
+        - test/**
     avoid-barrel-files: false
     avoid-missing-interpolation: false
     avoid-passing-self-as-argument: false
+    avoid-unassigned-stream-subscriptions:
+      exclude:
+        - test/**
     prefer-correct-handler-name: false
     match-lib-folder-structure: false
     avoid-duplicate-initializers: false

--- a/packages/solana/lib/src/base58/decode.dart
+++ b/packages/solana/lib/src/base58/decode.dart
@@ -1,4 +1,3 @@
-// @dart=3.9
 import 'dart:convert';
 
 part 'reverse_map.dart';

--- a/packages/solana/lib/src/base58/reverse_map.dart
+++ b/packages/solana/lib/src/base58/reverse_map.dart
@@ -1,4 +1,4 @@
-// @dart=3.9
+// ignore_for_file: avoid-duplicate-collection-elements
 part of 'decode.dart';
 
 const List<int> _reverseMap = [

--- a/packages/solana/lib/src/subscription_client/subscription_client.dart
+++ b/packages/solana/lib/src/subscription_client/subscription_client.dart
@@ -179,8 +179,8 @@ class SubscriptionClient {
 
     controller.onListen = () {
       int? subscriptionId;
-      var subscribeRequestSent = false;
-      var subscriptionCancelled = false;
+      bool subscribeRequestSent = false;
+      bool subscriptionCancelled = false;
       final requestId = _requestId++;
 
       final StreamSubscription<dynamic> subscription = _stream.listen(

--- a/packages/solana/lib/src/subscription_client/subscription_client.dart
+++ b/packages/solana/lib/src/subscription_client/subscription_client.dart
@@ -15,18 +15,21 @@ import 'package:solana/src/subscription_client/notification_message.dart';
 import 'package:solana/src/subscription_client/optional_error.dart';
 import 'package:solana/src/subscription_client/subscribed_message.dart';
 import 'package:solana/src/subscription_client/subscription_client_exception.dart';
-import 'package:web_socket_channel/io.dart';
+import 'package:solana/src/subscription_client/web_socket_channel_factory.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// Provides a websocket based connection to Solana.
 class SubscriptionClient {
+  /// [pingInterval] and [connectTimeout] are honored on IO platforms.
+  /// On web they are accepted for API compatibility and ignored.
   SubscriptionClient(Uri uri, {Duration? pingInterval, Duration? connectTimeout}) {
-    final channel = IOWebSocketChannel.connect(
+    final channel = createWebSocketChannel(
       uri,
       pingInterval: pingInterval,
       connectTimeout: connectTimeout,
     );
-    _sink = channel.sink;
+    _channel = channel;
+    _channelReady = channel.ready;
     _stream = channel.stream.asBroadcastStream();
   }
 
@@ -155,13 +158,14 @@ class SubscriptionClient {
 
   /// Dispose this object and cancel any existing subscription.
   void close() {
-    _sink.close();
     _isClosed = true;
+    _channel.sink.close();
   }
 
   static int _requestId = 1;
 
-  late final WebSocketSink _sink;
+  late final WebSocketChannel _channel;
+  late final Future<void> _channelReady;
   late final Stream<dynamic> _stream;
 
   bool _isClosed = false;
@@ -175,6 +179,8 @@ class SubscriptionClient {
 
     controller.onListen = () {
       int? subscriptionId;
+      var subscribeRequestSent = false;
+      var subscriptionCancelled = false;
       final requestId = _requestId++;
 
       final StreamSubscription<dynamic> subscription = _stream.listen(
@@ -201,16 +207,26 @@ class SubscriptionClient {
         onDone: controller.close,
       );
 
-      controller.onCancel = () {
-        subscription.cancel();
+      unawaited(
+        _channelReady.then((_) {
+          if (_isClosed || subscriptionCancelled) return;
+
+          subscribeRequestSent = true;
+          _sendRequest(requestId, '${method}Subscribe', params);
+        }, onError: (_, _) {}),
+      );
+
+      controller.onCancel = () async {
+        subscriptionCancelled = true;
+        await subscription.cancel();
+
+        if (!subscribeRequestSent) return;
 
         final id = subscriptionId;
         if (id == null) return;
 
         _sendRequest(_requestId++, '${method}Unsubscribe', <int>[id]);
       };
-
-      _sendRequest(requestId, '${method}Subscribe', params);
     };
 
     return controller.stream;
@@ -240,6 +256,6 @@ class SubscriptionClient {
       if (params != null) 'params': params,
     });
 
-    _sink.add(payload);
+    _channel.sink.add(payload);
   }
 }

--- a/packages/solana/lib/src/subscription_client/web_socket_channel_factory.dart
+++ b/packages/solana/lib/src/subscription_client/web_socket_channel_factory.dart
@@ -1,0 +1,3 @@
+export 'web_socket_channel_factory_default.dart'
+    if (dart.library.io) 'web_socket_channel_factory_io.dart'
+    if (dart.library.html) 'web_socket_channel_factory_web.dart';

--- a/packages/solana/lib/src/subscription_client/web_socket_channel_factory_default.dart
+++ b/packages/solana/lib/src/subscription_client/web_socket_channel_factory_default.dart
@@ -1,0 +1,7 @@
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+WebSocketChannel createWebSocketChannel(
+  Uri uri, {
+  Duration? pingInterval,
+  Duration? connectTimeout,
+}) => WebSocketChannel.connect(uri);

--- a/packages/solana/lib/src/subscription_client/web_socket_channel_factory_default.dart
+++ b/packages/solana/lib/src/subscription_client/web_socket_channel_factory_default.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid-unused-parameters
+
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 WebSocketChannel createWebSocketChannel(

--- a/packages/solana/lib/src/subscription_client/web_socket_channel_factory_io.dart
+++ b/packages/solana/lib/src/subscription_client/web_socket_channel_factory_io.dart
@@ -1,0 +1,8 @@
+import 'package:web_socket_channel/io.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+WebSocketChannel createWebSocketChannel(
+  Uri uri, {
+  Duration? pingInterval,
+  Duration? connectTimeout,
+}) => IOWebSocketChannel.connect(uri, pingInterval: pingInterval, connectTimeout: connectTimeout);

--- a/packages/solana/lib/src/subscription_client/web_socket_channel_factory_web.dart
+++ b/packages/solana/lib/src/subscription_client/web_socket_channel_factory_web.dart
@@ -1,0 +1,7 @@
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+WebSocketChannel createWebSocketChannel(
+  Uri uri, {
+  Duration? pingInterval,
+  Duration? connectTimeout,
+}) => WebSocketChannel.connect(uri);

--- a/packages/solana/lib/src/subscription_client/web_socket_channel_factory_web.dart
+++ b/packages/solana/lib/src/subscription_client/web_socket_channel_factory_web.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid-unused-parameters
+
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 WebSocketChannel createWebSocketChannel(

--- a/packages/solana/test/anchor_instruction_test.dart
+++ b/packages/solana/test/anchor_instruction_test.dart
@@ -1,4 +1,8 @@
 // @dart=3.9
+
+@TestOn('vm')
+library;
+
 import 'dart:io';
 
 import 'package:solana/anchor.dart';

--- a/packages/solana/test/mint_test.dart
+++ b/packages/solana/test/mint_test.dart
@@ -1,6 +1,9 @@
 // @dart=3.9
 // ignore_for_file: avoid-unnecessary-late
 
+@TestOn('vm')
+library;
+
 import 'package:solana/dto.dart' hide Instruction;
 import 'package:solana/encoder.dart';
 import 'package:solana/solana.dart';

--- a/packages/solana/test/rpc_client_test.dart
+++ b/packages/solana/test/rpc_client_test.dart
@@ -1,6 +1,9 @@
 // @dart=3.9
 // ignore_for_file: cast_nullable_to_non_nullable, avoid-unnecessary-late, avoid-type-casts
 
+@TestOn('vm')
+library;
+
 import 'dart:async';
 
 import 'package:bip39/bip39.dart';

--- a/packages/solana/test/rpc_client_test.dart
+++ b/packages/solana/test/rpc_client_test.dart
@@ -465,7 +465,7 @@ void main() {
     test('Call to getVersion() succeeds and parses the response correctly', () async {
       final version = await client.rpcClient.getVersion();
 
-      expect(version.solanaCore.codeUnitAt(0), anyOf(equals(50), equals(51)));
+      expect(version.solanaCore.codeUnitAt(0), anyOf(equals(50), equals(51), equals(52)));
       expect(version.solanaCore.codeUnitAt(1), equals(46));
     });
 

--- a/packages/solana/test/solana_client_test.dart
+++ b/packages/solana/test/solana_client_test.dart
@@ -1,6 +1,9 @@
 // @dart=3.9
 // ignore_for_file: avoid-unnecessary-late, avoid-type-casts
 
+@TestOn('vm')
+library;
+
 import 'package:solana/dto.dart';
 import 'package:solana/solana.dart';
 import 'package:test/test.dart';

--- a/packages/solana/test/subscription_client_lifecycle_test.dart
+++ b/packages/solana/test/subscription_client_lifecycle_test.dart
@@ -1,0 +1,120 @@
+// @dart=3.9
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:solana/solana.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('subscribe request is sent once websocket is ready', () async {
+    final subscribeRequest = Completer<Map<String, dynamic>>();
+    final server = await _bindServer((request) async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final socket = await WebSocketTransformer.upgrade(request);
+      socket.listen((dynamic message) {
+        if (!subscribeRequest.isCompleted) {
+          subscribeRequest.complete(_decodeRequest(message));
+          unawaited(socket.close());
+        }
+      });
+    });
+    addTearDown(() => server.close(force: true));
+
+    final client = SubscriptionClient(_toWebSocketUri(server));
+    addTearDown(client.close);
+
+    final subscription = client.slotSubscribe().listen((_) {});
+    addTearDown(subscription.cancel);
+
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(subscribeRequest.isCompleted, isFalse);
+
+    final request = await subscribeRequest.future.timeout(const Duration(seconds: 1));
+    expect(request['method'], 'slotSubscribe');
+  });
+
+  test('cancel sends unsubscribe after subscription id is received', () async {
+    final subscribeRequest = Completer<Map<String, dynamic>>();
+    final unsubscribeRequest = Completer<Map<String, dynamic>>();
+    final server = await _bindServer((request) async {
+      final socket = await WebSocketTransformer.upgrade(request);
+      socket.listen((dynamic message) {
+        final payload = _decodeRequest(message);
+        if (!subscribeRequest.isCompleted) {
+          subscribeRequest.complete(payload);
+          socket.add(
+            json.encode(<String, dynamic>{'jsonrpc': '2.0', 'result': 77, 'id': payload['id']}),
+          );
+
+          return;
+        }
+
+        if (!unsubscribeRequest.isCompleted) {
+          unsubscribeRequest.complete(payload);
+          unawaited(socket.close());
+        }
+      });
+    });
+    addTearDown(() => server.close(force: true));
+
+    final client = SubscriptionClient(_toWebSocketUri(server));
+    addTearDown(client.close);
+
+    final subscription = client.slotSubscribe().listen((_) {});
+    final request = await subscribeRequest.future.timeout(const Duration(seconds: 1));
+    expect(request['method'], 'slotSubscribe');
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    await subscription.cancel();
+
+    final unsubscribe = await unsubscribeRequest.future.timeout(const Duration(seconds: 1));
+    expect(unsubscribe['method'], 'slotUnsubscribe');
+    expect(unsubscribe['params'], <int>[77]);
+  });
+
+  test('cancel before websocket is ready does not send stale requests', () async {
+    final receivedRequest = Completer<Map<String, dynamic>>();
+    final server = await _bindServer((request) async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final socket = await WebSocketTransformer.upgrade(request);
+      unawaited(
+        Future<void>.delayed(const Duration(milliseconds: 150)).then((_) => socket.close()),
+      );
+      socket.listen((dynamic message) {
+        if (!receivedRequest.isCompleted) {
+          receivedRequest.complete(_decodeRequest(message));
+        }
+      });
+    });
+    addTearDown(() => server.close(force: true));
+
+    final client = SubscriptionClient(_toWebSocketUri(server));
+    addTearDown(client.close);
+
+    final subscription = client.slotSubscribe().listen((_) {});
+    await subscription.cancel();
+
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+    expect(receivedRequest.isCompleted, isFalse);
+  });
+}
+
+Future<HttpServer> _bindServer(Future<void> Function(HttpRequest request) onRequest) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((request) => unawaited(onRequest(request)));
+
+  return server;
+}
+
+Uri _toWebSocketUri(HttpServer server) =>
+    Uri(scheme: 'ws', host: server.address.address, port: server.port);
+
+Map<String, dynamic> _decodeRequest(dynamic message) =>
+    json.decode(message as String) as Map<String, dynamic>;

--- a/packages/solana/test/subscription_client_lifecycle_test.dart
+++ b/packages/solana/test/subscription_client_lifecycle_test.dart
@@ -18,10 +18,9 @@ void main() {
 
       final socket = await WebSocketTransformer.upgrade(request);
       socket.listen((dynamic message) {
-        if (!subscribeRequest.isCompleted) {
-          subscribeRequest.complete(_decodeRequest(message));
-          unawaited(socket.close());
-        }
+        if (subscribeRequest.isCompleted) return;
+        subscribeRequest.complete(_decodeRequest(message));
+        unawaited(socket.close());
       });
     });
     addTearDown(() => server.close(force: true));

--- a/packages/solana/test/subscription_client_test.dart
+++ b/packages/solana/test/subscription_client_test.dart
@@ -1,6 +1,9 @@
 // @dart=3.9
 // ignore_for_file: avoid-future-ignore
 
+@TestOn('vm')
+library;
+
 import 'dart:async';
 
 import 'package:solana/dto.dart';

--- a/packages/solana/test/subscription_client_web_test.dart
+++ b/packages/solana/test/subscription_client_web_test.dart
@@ -1,0 +1,17 @@
+// @dart=3.9
+
+@TestOn('browser')
+library;
+
+import 'package:solana/solana.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('constructor path is usable in browser builds', () async {
+    final client = SubscriptionClient.connect('http://localhost');
+    addTearDown(client.close);
+
+    final result = client.slotSubscribe().first.timeout(const Duration(seconds: 5));
+    await expectLater(result, throwsA(anything));
+  });
+}


### PR DESCRIPTION
## Summary
- make `SubscriptionClient` use a platform-specific websocket factory so the same API works on web and IO
- gate subscribe and unsubscribe requests on websocket readiness to avoid stale messages when listeners cancel early
- add VM lifecycle tests and a Chrome regression test, and mark validator-backed integration tests as VM-only

## Why
`SubscriptionClient` was hard-wired to `IOWebSocketChannel.connect`, which made the implementation IO-specific and prevented it from behaving cleanly in web builds. The subscribe flow also assumed the socket was immediately ready, which could race with cancellation.

## Impact
Web builds can now instantiate and use `SubscriptionClient` without changing the public API. IO keeps the current `pingInterval` and `connectTimeout` behavior, while web accepts those parameters as no-ops.

## Validation
- `dart analyze`
- `dart test test/subscription_client_lifecycle_test.dart`
- `dart test -p chrome test/subscription_client_web_test.dart`
- `dart test test/subscription_client_test.dart` (fails locally without the Solana validator/RPC running on `127.0.0.1:8899`)
